### PR TITLE
feat: parameterize metastore_id to replace hardcoded UUID

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,8 @@ TFSTATE_CONTAINER=workload-tfstate
 # -----------------------------------------------------------
 # Databricks workspace access
 # -----------------------------------------------------------
+DATABRICKS_ACCOUNT_ID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+METASTORE_ID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 DATABRICKS_HOST=https://xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 DATABRICKS_TOKEN=dapiXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 # Short-lived PAT for local dev only.

--- a/.github/workflows/workload-dbx.yaml
+++ b/.github/workflows/workload-dbx.yaml
@@ -88,6 +88,7 @@ jobs:
         run: |
           terraform -chdir=infra/workload-dbx plan -input=false -no-color \
             -var="databricks_account_id=${{ secrets.DATABRICKS_ACCOUNT_ID }}" \
+            -var="metastore_id=${{ secrets.METASTORE_ID }}" \
             -var="azure_workspace_resource_id=${{ steps.azout.outputs.WORKSPACE_RESOURCE_ID }}" \
             -var="workspace_name=${{ steps.azout.outputs.WORKSPACE_NAME }}" \
             -var="access_connector_id=${{ steps.azout.outputs.ACCESS_CONNECTOR_ID }}" \
@@ -102,6 +103,7 @@ jobs:
         run: |
           terraform -chdir=infra/workload-dbx apply -auto-approve -input=false -lock-timeout=10m -no-color \
             -var="databricks_account_id=${{ secrets.DATABRICKS_ACCOUNT_ID }}" \
+            -var="metastore_id=${{ secrets.METASTORE_ID }}" \
             -var="azure_workspace_resource_id=${{ steps.azout.outputs.WORKSPACE_RESOURCE_ID }}" \
             -var="workspace_name=${{ steps.azout.outputs.WORKSPACE_NAME }}" \
             -var="access_connector_id=${{ steps.azout.outputs.ACCESS_CONNECTOR_ID }}" \
@@ -115,6 +117,7 @@ jobs:
         run: |
           terraform -chdir=infra/workload-dbx destroy -auto-approve -input=false -lock-timeout=10m -no-color \
             -var="databricks_account_id=${{ secrets.DATABRICKS_ACCOUNT_ID }}" \
+            -var="metastore_id=${{ secrets.METASTORE_ID }}" \
             -var="azure_workspace_resource_id=${{ steps.azout.outputs.WORKSPACE_RESOURCE_ID }}" \
             -var="access_connector_id=${{ steps.azout.outputs.ACCESS_CONNECTOR_ID }}" \
             -var="storage_account_name=${{ steps.azout.outputs.STORAGE_ACCOUNT_NAME }}" \

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -18,6 +18,7 @@
 | `AZURE_CLIENT_ID` | App registration client ID (created below) |
 | `TFSTATE_SA_UNIQ` | Short unique suffix for state Storage Account name |
 | `DATABRICKS_ACCOUNT_ID` | Databricks Account ID (for Unity Catalog setup) |
+| `METASTORE_ID` | UUID of the existing Unity Catalog metastore |
 
 ---
 
@@ -104,6 +105,7 @@ AZURE_SUBSCRIPTION_ID=$SUB_ID
 AZURE_CLIENT_ID=$APP_ID
 TFSTATE_SA_UNIQ=<short unique suffix>
 DATABRICKS_ACCOUNT_ID=<your Databricks Account ID>
+METASTORE_ID=<your Unity Catalog metastore UUID>
 ```
 
 ---

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -46,6 +46,7 @@ vars:
 
   # === Workload variables (DBX) ===
   DATABRICKS_ACCOUNT_ID: "{{.DATABRICKS_ACCOUNT_ID | default ``}}"
+  METASTORE_ID: "{{.METASTORE_ID | default ``}}"
   CATALOG_NAME: "{{.CATALOG_NAME | default `mock`}}"
   SCHEMAS_JSON: "{{.SCHEMAS_JSON | default `[\"staging\",\"serving\"]`}}" # FIXME: backslash might have an issue
 
@@ -484,6 +485,7 @@ tasks:
           -var="subscription_id={{.AZURE_SUBSCRIPTION_ID}}" \
           -var="azure_tenant_id={{.AZURE_TENANT_ID}}" \
           -var="databricks_account_id={{.DATABRICKS_ACCOUNT_ID}}" \
+          -var="metastore_id={{.METASTORE_ID}}" \
           -var="azure_workspace_resource_id=${WORKSPACE_RESOURCE_ID}" \
           -var="workspace_name=${WORKSPACE_NAME}" \
           -var="resource_group_name={{.RG_NAME}}" \
@@ -510,6 +512,7 @@ tasks:
           -var="subscription_id={{.AZURE_SUBSCRIPTION_ID}}" \
           -var="azure_tenant_id={{.AZURE_TENANT_ID}}" \
           -var="databricks_account_id={{.DATABRICKS_ACCOUNT_ID}}" \
+          -var="metastore_id={{.METASTORE_ID}}" \
           -var="azure_workspace_resource_id=${WORKSPACE_RESOURCE_ID}" \
           -var="workspace_name=${WORKSPACE_NAME}" \
           -var="resource_group_name={{.RG_NAME}}" \
@@ -535,6 +538,7 @@ tasks:
           -var="subscription_id={{.AZURE_SUBSCRIPTION_ID}}" \
           -var="azure_tenant_id={{.AZURE_TENANT_ID}}" \
           -var="databricks_account_id={{.DATABRICKS_ACCOUNT_ID}}" \
+          -var="metastore_id={{.METASTORE_ID}}" \
           -var="azure_workspace_resource_id=${WORKSPACE_RESOURCE_ID}" \
           -var="workspace_name=${WORKSPACE_NAME}" \
           -var="resource_group_name={{.RG_NAME}}" \
@@ -562,6 +566,7 @@ tasks:
           -var=subscription_id={{.AZURE_SUBSCRIPTION_ID}}
           -var=azure_tenant_id={{.AZURE_TENANT_ID}}
           -var=databricks_account_id={{.DATABRICKS_ACCOUNT_ID}}
+          -var=metastore_id={{.METASTORE_ID}}
           -var=azure_workspace_resource_id=${WORKSPACE_RESOURCE_ID}
           -var=workspace_name=${WORKSPACE_NAME}
           -var=resource_group_name={{.RG_NAME}}

--- a/infra/workload-dbx/main.tf
+++ b/infra/workload-dbx/main.tf
@@ -40,8 +40,7 @@ resource "databricks_metastore" "this" {
   # name         = "mvp-metastore"
   name = var.catalog_name
   # storage_root = local.storage_root_abfss
-  storage_root = "abfss://${var.uc_root_container}@${var.storage_account_name}.dfs.core.windows.net/30ebd5eb-ba32-4617-b715-1bbad2ad51e0"
-  # TODO: parameterize hardcoded metastore ID.
+  storage_root = "abfss://${var.uc_root_container}@${var.storage_account_name}.dfs.core.windows.net/${var.metastore_id}"
   lifecycle {
     ignore_changes  = [storage_root, owner]
     # prevent_destroy = true # enable if you want to keep this metastore permananent.

--- a/infra/workload-dbx/variables.tf
+++ b/infra/workload-dbx/variables.tf
@@ -50,6 +50,11 @@ variable "uc_root_container" {
   default     = "uc-root"
 }
 
+variable "metastore_id" {
+  description = "UUID of the existing Unity Catalog metastore (used as the storage_root path suffix)"
+  type        = string
+}
+
 # variable "catalog_name" {
 #   description = "Name of the catalog to create under the metastore"
 #   type        = string


### PR DESCRIPTION
## Summary

- Add `variable "metastore_id"` to `infra/workload-dbx/variables.tf`
- Replace hardcoded UUID in `main.tf` `storage_root` with `var.metastore_id`
- Propagate `METASTORE_ID` through `Taskfile.yml` (all dbx tasks) and `.github/workflows/workload-dbx.yaml` (plan/apply/destroy steps via `secrets.METASTORE_ID`)
- Add `METASTORE_ID` placeholder to `.env.example` and document the GitHub secret in `GETTING_STARTED.md`

## Test plan

- [ ] Add `METASTORE_ID=<uuid>` to local `.env` and run `task dbx:plan` to verify no missing variable errors
- [ ] Confirm `METASTORE_ID` secret is set in GitHub repository settings
- [ ] Trigger `workload-dbx` workflow on this PR to verify plan step passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)