### PR TITLE
fix: mirror workspace_name var flag from apply to destroy step

### DIFF
--- a/.github/workflows/workload-dbx.yaml
+++ b/.github/workflows/workload-dbx.yaml
@@ -119,6 +119,7 @@ jobs:
             -var="databricks_account_id=${{ secrets.DATABRICKS_ACCOUNT_ID }}" \
             -var="metastore_id=${{ secrets.METASTORE_ID }}" \
             -var="azure_workspace_resource_id=${{ steps.azout.outputs.WORKSPACE_RESOURCE_ID }}" \
+            -var="workspace_name=${{ steps.azout.outputs.WORKSPACE_NAME }}" \
             -var="access_connector_id=${{ steps.azout.outputs.ACCESS_CONNECTOR_ID }}" \
             -var="storage_account_name=${{ steps.azout.outputs.STORAGE_ACCOUNT_NAME }}" \
             -var="uc_root_container=${{ steps.azout.outputs.UC_ROOT_CONTAINER }}" \


### PR DESCRIPTION
## Summary

- The `Terraform Destroy` step was missing `-var="workspace_name=..."` that exists in both the Plan and Apply steps.
- Added the missing flag so all three steps pass the same set of `-var` arguments.

## Test plan

- [ ] Trigger `workflow_dispatch` with `destroy: true` and confirm the destroy plan resolves `workspace_name` without an unknown-variable error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)