### PR TITLE
docs: consolidate issue #8 into #15 and add Destroy symptom

### DIFF
--- a/docs/code-review-2026-03-02.md
+++ b/docs/code-review-2026-03-02.md
@@ -177,7 +177,7 @@ Three variables were declared in `variables.tf` with no default and no correspon
 
 **Resolution:** Removed the two undeclared `-var` flags and added the three missing ones to all steps. `CATALOG_NAME`/`SCHEMAS` env vars replaced with `RG_NAME: rg-mock-data`. Fixed in PR #14 (`fix/var-flag-mismatches-issue-6`). Confirmed by CI run [22561717749](https://github.com/nobhri/azure-dbx-mock-platform/actions/runs/22561717749) — no `Value for undeclared variable` errors.
 
-**Separate issue — empty secret:** The CI log shows `-var="databricks_account_id="` — the `DATABRICKS_ACCOUNT_ID` GitHub Secret resolves to an empty string. This is a repo configuration issue, not a code fix. → [Issue #8](https://github.com/nobhri/azure-dbx-mock-platform/issues/8)
+**Separate issue — empty secret:** The CI log shows `-var="databricks_account_id="` — the `DATABRICKS_ACCOUNT_ID` GitHub Secret resolves to an empty string. This is a repo configuration issue, not a code fix. Because `databricks_metastore.this` uses `provider = databricks.account`, Terraform refreshes state via the account-scope provider on every operation — **all three steps (Plan, Apply, Destroy) are blocked** until the secret is populated. → [Issue #15](https://github.com/nobhri/azure-dbx-mock-platform/issues/15) *(consolidates closed #8)*
 
 ### infra/workload-dbx/providers.tf
 
@@ -301,7 +301,7 @@ No credentials, tokens, or secrets were found anywhere in the codebase.
 | 1a | — | `workspace_name` absent from Destroy step only | `workload-dbx.yaml` destroy step | — | **Fixed — PR #5** |
 | 2 | HIGH | Hardcoded environment-specific metastore UUID | `workload-dbx/main.tf:43` | — | **Fixed — PR #3** |
 | 3 | HIGH | Hardcoded ADLS storage account name | `workload-azure.yaml:29` | [#7](https://github.com/nobhri/azure-dbx-mock-platform/issues/7) | Open |
-| 4 | MEDIUM | `DATABRICKS_ACCOUNT_ID` GitHub Secret is empty — resolves to empty string in CI | GitHub repo secrets | [#8](https://github.com/nobhri/azure-dbx-mock-platform/issues/8) | Open (config, not code) |
+| 4 | HIGH | `DATABRICKS_ACCOUNT_ID` GitHub Secret is empty — blocks Plan, Apply, and Destroy (account-scope provider refresh fails on all operations) | GitHub repo secrets | [#15](https://github.com/nobhri/azure-dbx-mock-platform/issues/15) | Open (config, not code) |
 | 5 | LOW | Commented-out catalog/schema resources lack explanation | `workload-dbx/main.tf:96–147` | [#9](https://github.com/nobhri/azure-dbx-mock-platform/issues/9) | Open |
 | 6 | LOW | `SCHEMAS_JSON` escaping issue | `Taskfile.yml:50` | [#10](https://github.com/nobhri/azure-dbx-mock-platform/issues/10) | Open |
 | 7 | LOW | No `tflint` or `checkov` runs in CI/CD (tasks exist but not invoked) | `Taskfile.yml`, all workflows | [#11](https://github.com/nobhri/azure-dbx-mock-platform/issues/11) | Open |
@@ -329,7 +329,7 @@ No credentials, tokens, or secrets were found anywhere in the codebase.
 
 1. ~~**Add `variable "metastore_id" {}`** to `workload-dbx/variables.tf` and replace the hardcoded UUID in `main.tf:43`~~ **Done — PR #3**
 2. ~~**Fix variable mismatch** in `workload-dbx.yaml`: remove `-var="catalog_name=..."` and `-var='schema_names=[...]'` from all 3 steps; add `-var="subscription_id=..."`, `-var="azure_tenant_id=..."`, `-var="resource_group_name=rg-mock-data"` to all 3 steps. Also fix `main.tf:41` referencing undeclared `var.catalog_name`.~~ **Done — PR #14** → [Issue #6](https://github.com/nobhri/azure-dbx-mock-platform/issues/6)
-3. **Set `DATABRICKS_ACCOUNT_ID`** in GitHub repo Secrets — the secret currently resolves to an empty string in CI. → [Issue #8](https://github.com/nobhri/azure-dbx-mock-platform/issues/8)
+3. **Set `DATABRICKS_ACCOUNT_ID`** in GitHub repo Secrets — the secret currently resolves to an empty string in CI, blocking Plan, Apply, and Destroy. → [Issue #15](https://github.com/nobhri/azure-dbx-mock-platform/issues/15)
 4. **Move `ADLS_NAME`** to a GitHub Secret and reference it as `${{ secrets.ADLS_STORAGE_NAME }}` in `workload-azure.yaml` → [Issue #7](https://github.com/nobhri/azure-dbx-mock-platform/issues/7)
 
 ### Fix Soon (medium effort)


### PR DESCRIPTION
## Summary

- Replaces all three `#8` references in `docs/code-review-2026-03-02.md` with `#15` (issue #8 was closed as a duplicate of #15)
- Upgrades the `DATABRICKS_ACCOUNT_ID` row severity from MEDIUM → HIGH, consistent with issue #15's classification
- Adds the Destroy symptom: because `databricks_metastore.this` uses `provider = databricks.account`, the account-scope provider refresh runs on every Terraform operation — Plan, Apply, and Destroy are all blocked until the secret is set

## Test plan

- [ ] Verify all three previous `#8` links now point to `#15`
- [ ] Verify "Issues by Severity" row 4 shows HIGH and links to #15
- [ ] Verify Recommendations item 3 links to #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)