### PR TITLE
fix: skip Read outputs step during destroy to prevent ANSI $GITHUB_OUTPUT error

### DIFF
--- a/.github/workflows/workload-azure.yaml
+++ b/.github/workflows/workload-azure.yaml
@@ -110,7 +110,7 @@ jobs:
 
       # Expose outputs for the dbx workflow to reuse if needed
       - name: Read outputs
-        if: always()
+        if: always() && inputs.destroy != true
         id: tfout
         run: |
           echo "WORKSPACE_RESOURCE_ID=$(terraform -chdir=infra/workload-azure output -raw workspace_resource_id)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary

- Fixes `if: always()` → `if: always() && inputs.destroy != true` on the "Read outputs" step in `workload-azure.yaml`

## Root cause

After `terraform destroy`, `terraform output -raw <key>` prints ANSI-formatted warning text (`│ Warning: No outputs found`) rather than a real value. The step was writing this verbatim into `$GITHUB_OUTPUT`, which GitHub Actions rejected:

```
Unable to process file command 'output' successfully.
Invalid format '[33m│[0m [0m[1m[33mWarning: [0m[0m[1mNo outputs found[0m'
```

## Change

```yaml
# Before
if: always()

# After
if: always() && inputs.destroy != true
```

## Test plan

- [ ] Trigger `workload-azure` with `destroy: true` — "Read outputs" step should be skipped
- [ ] Trigger `workload-azure` apply — "Read outputs" step should still run

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)