### PR TITLE
fix: resolve SCHEMAS_JSON shell escaping in dbx:destroy (issue #10)

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -48,7 +48,7 @@ vars:
   DATABRICKS_ACCOUNT_ID: "{{.DATABRICKS_ACCOUNT_ID | default ``}}"
   METASTORE_ID: "{{.METASTORE_ID | default ``}}"
   CATALOG_NAME: "{{.CATALOG_NAME | default `mock`}}"
-  SCHEMAS_JSON: "{{.SCHEMAS_JSON | default `[\"staging\",\"serving\"]`}}" # FIXME: backslash might have an issue
+  SCHEMAS_JSON: "{{.SCHEMAS_JSON | default `[\"staging\",\"serving\"]`}}"
 
   # === Directories ===
   AZ_DIR: "{{.AZ_DIR | default `infra/workload-azure`}}"
@@ -556,6 +556,8 @@ tasks:
       DATABRICKS_HOST: ""
       DATABRICKS_TOKEN: ""
       DATABRICKS_WAREHOUSE_ID: ""
+      # Pass schema_names via TF_VAR_ to avoid unquoted-expansion glob issues with JSON brackets.
+      TF_VAR_schema_names: "{{.SCHEMAS_JSON}}"
     cmds:
       - |
         set -euo pipefail
@@ -574,7 +576,6 @@ tasks:
           -var=storage_account_name=${STORAGE_ACCOUNT_NAME}
           -var=uc_root_container=${UC_ROOT_CONTAINER}
           -var=catalog_name={{.CATALOG_NAME}}
-          -var=schema_names={{.SCHEMAS_JSON}}
         "
 
         echo "==> Step 1: Destroy grants"


### PR DESCRIPTION
## Summary

- **Root cause analysis**: The YAML `\"` in the double-quoted `SCHEMAS_JSON` default correctly unescapes to `"` before Go template processing, so the backtick literal `["staging","serving"]` is already valid JSON. The FIXME concern was unfounded — the default value was always correct.
- **Actual bug**: In `dbx:destroy`, `schema_names={{.SCHEMAS_JSON}}` was embedded inside a double-quoted `COMMON_VARS` string and then expanded **unquoted** (`$COMMON_VARS`). The `["staging","serving"]` value contains `[` and `]`, which shell glob-expands when unquoted, making the argument fragile.
- **Fix**: Removed the `-var=schema_names=...` line from `COMMON_VARS` and moved it to `TF_VAR_schema_names` in the task's `env:` block. Terraform auto-reads `TF_VAR_*` environment variables, so no `-var` flag is needed and there is no quoting risk.
- Removed the FIXME comment.

## Test plan

- [ ] `task dbx:plan` — still passes `schema_names` via `-var='schema_names=...'` (unchanged, already correct)
- [ ] `task dbx:apply` — same as above
- [ ] `task dbx:destroy` — now passes `schema_names` via `TF_VAR_schema_names` env var; no glob expansion possible

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)