### PR TITLE
fix: replace hardcoded ADLS name with GitHub secret

### DIFF
--- a/.github/workflows/workload-azure.yaml
+++ b/.github/workflows/workload-azure.yaml
@@ -26,7 +26,7 @@ env:
   TFSTATE_KEY: azure.tfstate
   LOCATION: japaneast
   RG_NAME: rg-mock-data
-  ADLS_NAME: stdataabcdedata     # HACKME: Parameterize and write it on .env, etc.
+  ADLS_NAME: ${{ secrets.ADLS_STORAGE_NAME }}
   WORKSPACE_SKU: premium
   PREFIX: mock
 


### PR DESCRIPTION
## Summary

- Replaces `ADLS_NAME: stdataabcdedata` (hardcoded, globally-unique Azure Storage Account name) with `${{ secrets.ADLS_STORAGE_NAME }}`
- Any deployer now supplies their own storage account name via repo secret `ADLS_STORAGE_NAME`

## Required action

Add the `ADLS_STORAGE_NAME` secret to GitHub repo settings → Secrets and variables → Actions, with value set to your ADLS Gen2 storage account name.

## Test plan

- [ ] Verify `ADLS_STORAGE_NAME` secret is set in repo settings
- [ ] Trigger `workload-azure` workflow — confirm `ADLS_NAME` resolves correctly and Terraform plan/apply succeeds

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)