### PR TITLE
docs: add explanatory comment above commented-out catalog/schema block

### DIFF
--- a/infra/workload-dbx/main.tf
+++ b/infra/workload-dbx/main.tf
@@ -89,7 +89,10 @@ resource "databricks_external_location" "uc_root" {
   depends_on = [databricks_metastore_assignment.this]
 }
 
-# catalog and schema are going to be created with DDL SQL
+# Catalog and schema management is intentionally handled outside Terraform.
+# See ADR-001: Jinja2 + Python Notebook manages catalog/schema to avoid
+# Terraform lifecycle conflicts with Unity Catalog bootstrap ordering.
+# The resources below were prototyped but deferred to the notebook layer.
 
 # # Catalog under the attached metastore
 # resource "databricks_catalog" "catalog" {


### PR DESCRIPTION
## Summary
- Replaces the one-liner `# catalog and schema are going to be created with DDL SQL` with a 4-line block that explains the intent clearly
- States the resources are intentionally deferred (not abandoned) and references ADR-001
- Closes #9

## Test plan
- [ ] Review `infra/workload-dbx/main.tf` lines 92–96 — comment block is clear and references ADR-001
- [ ] No functional code changed; Terraform plan is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)