### PR TITLE
docs: warn against running terraform from repo root (fixes #12)

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -163,6 +163,7 @@ METASTORE_ID=<your Unity Catalog metastore UUID>
 - **Storage Account names are hardcoded in two places — replace before deploying:**
   - Terraform state backend Storage Account
   - Unity Catalog root storage Storage Account
+- **Do not run `terraform` from the repo root** — always use `-chdir=infra/<module>` (or let CI do it). Running terraform at the root creates a local `terraform.tfstate` in the repo root that is out of sync with the remote backend. The file is excluded by `.gitignore` but indicates an accidental manual run outside the intended module directory.
 
 ---
 


### PR DESCRIPTION
## Summary
- Confirmed `terraform.tfstate` in repo root had `"resources": []` — empty, no real infrastructure tracked, safe to delete
- Deleted the file locally (already excluded by `.gitignore`, no git diff)
- Added a **Common Pitfalls** entry to `GETTING_STARTED.md` explaining that all Terraform runs must use `-chdir=infra/<module>` to prevent stale local state files

## Test plan
- [ ] Verify `GETTING_STARTED.md` renders correctly on GitHub
- [ ] Confirm `terraform.tfstate` no longer exists in repo root

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)