### PR TITLE
feat: add tflint step to workload-azure and workload-dbx CI (#11)

### DIFF
--- a/.github/workflows/workload-azure.yaml
+++ b/.github/workflows/workload-azure.yaml
@@ -68,6 +68,14 @@ jobs:
             -backend-config="container_name=$TFSTATE_CONTAINER" \
             -backend-config="key=$TFSTATE_KEY"
 
+      - name: Setup tflint
+        uses: terraform-linters/setup-tflint@v4
+
+      - name: tflint
+        run: |
+          tflint --init --chdir=infra/workload-azure
+          tflint --chdir=infra/workload-azure
+
       - name: Terraform Plan (PR)
         if: github.event_name == 'pull_request'
         run: |

--- a/.github/workflows/workload-dbx.yaml
+++ b/.github/workflows/workload-dbx.yaml
@@ -82,6 +82,14 @@ jobs:
             -backend-config="container_name=$TFSTATE_CONTAINER" \
             -backend-config="key=$TFSTATE_KEY"
 
+      - name: Setup tflint
+        uses: terraform-linters/setup-tflint@v4
+
+      - name: tflint
+        run: |
+          tflint --init --chdir=infra/workload-dbx
+          tflint --chdir=infra/workload-dbx
+
       - name: Terraform Plan (PR)
         if: github.event_name == 'pull_request'
         run: |

--- a/infra/workload-azure/.tflint.hcl
+++ b/infra/workload-azure/.tflint.hcl
@@ -1,0 +1,5 @@
+plugin "azurerm" {
+  enabled = true
+  source  = "github.com/terraform-linters/tflint-ruleset-azurerm"
+  version = "0.27.0"
+}

--- a/infra/workload-dbx/.tflint.hcl
+++ b/infra/workload-dbx/.tflint.hcl
@@ -1,0 +1,1 @@
+# No official tflint ruleset for the Databricks provider; core rules apply.


### PR DESCRIPTION
## Summary
- Adds `terraform-linters/setup-tflint@v4` + `tflint --init` / `tflint --chdir` steps after **Terraform Init** in both `workload-azure.yaml` and `workload-dbx.yaml`
- Introduces `infra/workload-azure/.tflint.hcl` enabling the `tflint-ruleset-azurerm` plugin (v0.27.0)
- Introduces `infra/workload-dbx/.tflint.hcl` (core rules only — no official Databricks tflint ruleset exists yet)

Closes #11. Checkov to follow in a separate PR per issue notes.

## Test plan
- [ ] PR triggers `workload-azure` workflow — verify tflint step passes
- [ ] PR triggers `workload-dbx` workflow — verify tflint step passes
- [ ] Confirm no false positives block existing valid Terraform code

🤖 Generated with [Claude Code](https://claude.com/claude-code)