### PR TITLE
docs: add git worktree workflow for parallel Claude Code sessions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,8 @@ Azure, Terraform, Databricks, Asset Bundles, Unity Catalog, Jinja2, GitHub Actio
 - Always create a new branch before making any changes
 - Never commit directly to main
 - Always create PR to main, never push to main directly
+- Use git worktrees (`.claude/worktrees/<branch-name>`) for parallel sessions (e.g. tmux with multiple Claude Code terminals)
+- Each worktree gets its own branch; all worktrees target main via PR
 
 ## Boundaries
 - NEVER approve or merge pull requests


### PR DESCRIPTION
## Summary
- Documents the git worktree pattern for running parallel Claude Code sessions (e.g. multiple tmux terminals)
- Each worktree uses its own branch under `.claude/worktrees/<branch-name>/`
- All worktrees continue to target `main` via PR

## Test plan
- [ ] Verify CLAUDE.md renders correctly on GitHub
- [ ] Confirm the worktree convention is clear for future sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)