### PR TITLE
fix: ignore tmux session log files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,5 +59,8 @@ venv/
 .DS_Store
 Thumbs.db
 
+# --- tmux ---
+tmux-*.log
+
 # --- Claude Code ---
 .claude/


### PR DESCRIPTION
## Summary
- Adds `tmux-*.log` to `.gitignore` under a new `# --- tmux ---` section
- Covers both `tmux-client-<PID>.log` and `tmux-server-<PID>.log` (PID changes each session)
- These files are transient artifacts created when tmux is started from the repo root

## Test plan
- [ ] Confirm `tmux-client-*.log` and `tmux-server-*.log` no longer appear as untracked in `git status`

🤖 Generated with [Claude Code](https://claude.com/claude-code)