### PR TITLE
fix: make BUDGET_END dynamic to prevent expiry (issue #41)

### DIFF
--- a/.github/workflows/guardrails.yaml
+++ b/.github/workflows/guardrails.yaml
@@ -21,7 +21,7 @@ env:
   SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
   BUDGET_AMOUNT: "2000"                 # override if you like
   BUDGET_START: "2025-01-01T00:00:00Z"
-  BUDGET_END:   "2026-01-01T00:00:00Z"
+  BUDGET_END:   "2027-01-01T00:00:00Z"
   ALERT_EMAIL:  ${{ secrets.ALERT_EMAIL }}
 
 jobs:
@@ -49,12 +49,15 @@ jobs:
             -backend-config="container_name=${TFSTATE_CONTAINER}" \
             -backend-config="key=${TFSTATE_KEY}"
 
-      - name: Set budget dates to current month
-        run: echo "BUDGET_START=$(date -u +'%Y-%m-01T00:00:00Z')" >> $GITHUB_ENV
+      - name: Set budget dates
+        run: |
+          echo "BUDGET_START=$(date -u +'%Y-%m-01T00:00:00Z')" >> $GITHUB_ENV
+          echo "BUDGET_END=$(($(date -u +'%Y') + 1))-01-01T00:00:00Z" >> $GITHUB_ENV
 
       - name: Terraform apply (budget + alerts)
         run: |
           terraform -chdir=infra/guardrails apply -auto-approve -input=false -lock-timeout=10m \
             -var="budget_amount=${BUDGET_AMOUNT}" \
             -var="budget_start=${{ env.BUDGET_START }}" \
+            -var="budget_end=${{ env.BUDGET_END }}" \
             -var='alert_emails=["'${{ env.ALERT_EMAIL }}'"]'

--- a/infra/guardrails/variables.tf
+++ b/infra/guardrails/variables.tf
@@ -11,7 +11,7 @@ variable "budget_start" {
 
 variable "budget_end" {
   type    = string
-  default = "2026-01-01T00:00:00Z"
+  default = "2027-01-01T00:00:00Z"
 }
 
 variable "alert_emails" {


### PR DESCRIPTION
## Summary
- `BUDGET_END` was hardcoded to `2026-01-01T00:00:00Z`, which had already passed, causing Azure to reject budget creation with a 400 error
- The `BUDGET_END` env var in the workflow was never passed as a `-var` to Terraform, so the expired default in `variables.tf` was always used
- This PR fixes both issues by computing `BUDGET_END` dynamically as next year's Jan 1, and wiring it through to the Terraform apply command

## Changes
- `.github/workflows/guardrails.yaml`: "Set budget dates" step now also computes `BUDGET_END=$((YEAR + 1))-01-01T00:00:00Z`; `-var="budget_end=..."` added to terraform apply
- `infra/guardrails/variables.tf`: default updated to `2027-01-01T00:00:00Z` as a safe fallback

## Test plan
- [ ] Trigger `guardrails` workflow via `workflow_dispatch` and confirm Terraform apply succeeds
- [ ] Verify budget start = first of current month, end = Jan 1 of next year in Azure portal

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)