### PR TITLE
fix: inputs.destroy boolean comparison broken in workload-azure (#45)

### DIFF
--- a/.github/workflows/workload-azure.yaml
+++ b/.github/workflows/workload-azure.yaml
@@ -79,7 +79,7 @@ jobs:
             -var="workspace_sku=$WORKSPACE_SKU"
 
       - name: Terraform Apply (main)
-        if: github.ref == 'refs/heads/main' && inputs.destroy != 'true'
+        if: github.ref == 'refs/heads/main' && inputs.destroy != true
         env: { TF_IN_AUTOMATION: "1" }
         run: |
           terraform -chdir=infra/workload-azure apply -auto-approve -input=false -lock-timeout=10m -no-color \
@@ -90,7 +90,7 @@ jobs:
             -var="workspace_sku=$WORKSPACE_SKU"
 
       - name: Terraform Destroy (manual)
-        if: inputs.destroy == 'true'
+        if: inputs.destroy == true
         run: |
           terraform -chdir=infra/workload-azure destroy -auto-approve -input=false -lock-timeout=10m -no-color \
             -var="prefix=$PREFIX" \
@@ -110,7 +110,7 @@ jobs:
 
       # Expose outputs for the dbx workflow to reuse if needed
       - name: Read outputs
-        if: always() && inputs.destroy != 'true'
+        if: always() && inputs.destroy != true
         id: tfout
         run: |
           echo "WORKSPACE_RESOURCE_ID=$(terraform -chdir=infra/workload-azure output -raw workspace_resource_id)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary

- Fixes inputs.destroy comparisons: `'true'` (string) → `true` (boolean) in all three `if:` conditions in `.github/workflows/workload-azure.yaml`

## Root cause

`workflow_dispatch` declares `destroy` as `type: boolean`, but the conditions compared it against the string `'true'`. GitHub Actions coerces mismatched types to numbers: boolean `true` → `1`, string `'true'` → `NaN`. So `== 'true'` was always `false` (Destroy never ran) and `!= 'true'` was always `true` (Apply always ran).

## Changed lines

| Line | Before | After |
|------|--------|-------|
| 82 | `inputs.destroy != 'true'` | `inputs.destroy != true` |
| 93 | `inputs.destroy == 'true'` | `inputs.destroy == true` |
| 113 | `inputs.destroy != 'true'` | `inputs.destroy != true` |

## Test plan

- [ ] Trigger `workload-azure` via `workflow_dispatch` with `destroy: true` — Destroy step runs, Apply and Read outputs are skipped
- [ ] Trigger with `destroy: false` (default) — Apply and Read outputs run, Destroy is skipped

Closes #45. Regression from PR #30 (issue #28).

🤖 Generated with [Claude Code](https://claude.com/claude-code)