### PR TITLE
fix: correct inputs.destroy boolean comparison in workload-dbx (#47)

### DIFF
--- a/.github/workflows/workload-dbx.yaml
+++ b/.github/workflows/workload-dbx.yaml
@@ -98,7 +98,7 @@ jobs:
             -var="uc_root_container=${{ steps.azout.outputs.UC_ROOT_CONTAINER }}"
 
       - name: Terraform Apply (main)
-        if: github.ref == 'refs/heads/main' && inputs.destroy != 'true'
+        if: github.ref == 'refs/heads/main' && inputs.destroy != true
         env: { TF_IN_AUTOMATION: "1" }
         run: |
           terraform -chdir=infra/workload-dbx apply -auto-approve -input=false -lock-timeout=10m -no-color \
@@ -114,7 +114,7 @@ jobs:
             -var="uc_root_container=${{ steps.azout.outputs.UC_ROOT_CONTAINER }}"
 
       - name: Terraform Destroy (manual)
-        if: inputs.destroy == 'true'
+        if: inputs.destroy == true
         run: |
           terraform -chdir=infra/workload-dbx destroy -auto-approve -input=false -lock-timeout=10m -no-color \
             -var="subscription_id=${{ secrets.AZURE_SUBSCRIPTION_ID }}" \


### PR DESCRIPTION
## Summary

Fixes #47 — `inputs.destroy` boolean comparison in `workload-dbx.yaml` was comparing a boolean input against the string `'true'`, causing destroy to never run and apply to always run.

## Root cause

GitHub Actions coerces mismatched types: `boolean true` → `1`, `string 'true'` → `NaN`, so `1 == NaN` is always `false`.

## Changes

`.github/workflows/workload-dbx.yaml`:

| Line | Before | After |
|------|--------|-------|
| 101 | `inputs.destroy != 'true'` | `inputs.destroy != true` |
| 117 | `inputs.destroy == 'true'` | `inputs.destroy == true` |

## Related

- Closes #47
- Same root cause as #45 (fixed in PR #48 for `workload-azure.yaml`)
- Restores the destroy/recreate cost-saving procedure

🤖 Generated with [Claude Code](https://claude.com/claude-code)