### PR TITLE
fix: add force_destroy to metastore to unblock CI destroy

### DIFF
--- a/infra/workload-dbx/main.tf
+++ b/infra/workload-dbx/main.tf
@@ -40,6 +40,10 @@ resource "databricks_metastore" "this" {
   name = "mvp-metastore"
   # storage_root = local.storage_root_abfss
   storage_root = "abfss://${var.uc_root_container}@${var.storage_account_name}.dfs.core.windows.net/${var.metastore_id}"
+  # force_destroy allows Terraform destroy to cascade-delete all UC objects
+  # (catalogs, schemas, storage credentials) even when not managed by Terraform
+  # (e.g. catalog/schema created by Jinja2 notebook — see ADR-001).
+  force_destroy = true
   lifecycle {
     ignore_changes  = [storage_root, owner]
     # prevent_destroy = true # enable if you want to keep this metastore permananent.


### PR DESCRIPTION
## Problem

`workload-dbx` destroy fails in CI with:

```
Error: cannot delete metastore: Metastore '...' is not empty.
The metastore has 1 catalog(s), 1 storage credential(s)
```

The catalog is created by the Jinja2/Python notebook (ADR-001, not Terraform), so it is never in Terraform state. On destroy, Terraform has no knowledge of it and cannot clean it up before deleting the metastore.

## Fix

Add `force_destroy = true` to `databricks_metastore.this`. This instructs the Databricks API to cascade-delete all child UC objects (catalogs, schemas, storage credentials) regardless of whether they are in Terraform state.

## Notes

- This supersedes the manual workaround documented in issue #26
- Related to issue #26 (UC objects orphaned when destroy order is wrong)
- The `force_destroy` flag only takes effect on `terraform destroy` — no impact on apply

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)