### PR TITLE
fix: remove unsupported workspace.host interpolation in databricks.yml

### DIFF
--- a/platform/databricks.yml
+++ b/platform/databricks.yml
@@ -6,9 +6,6 @@ variables:
     description: "Target environment (dev|staging|prod)"
     default: dev
 
-workspace:
-  host: ${DATABRICKS_HOST}   # injected by CI workflow
-
 targets:
   dev:
     mode: development


### PR DESCRIPTION
## Summary
- Removes `workspace.host: ${DATABRICKS_HOST}` from `platform/databricks.yml`
- Databricks Asset Bundles do not support variable interpolation (`${...}`) for authentication fields — this causes the error: `failed during request visitor: parse "https://${DATABRICKS_HOST}": invalid character "{" in host name`
- The Databricks CLI automatically reads `DATABRICKS_HOST` from the environment, which is already set by the CI workflow

## Root Cause
`workload-catalog` failed on push to main after PR #54 merged:
```
Error: failed during request visitor: parse "https://${DATABRICKS_HOST}": invalid character "{" in host name
```
Asset Bundles treat `${DATABRICKS_HOST}` as a bundle variable reference, not a shell variable. Auth fields (`workspace.host`, `workspace.token`) must be set via env vars, not bundle interpolation.

## Test plan
- [ ] PR CI passes (OIDC subject mismatch is a known separate issue #40, may still block `pull_request` runs)
- [ ] `workload-catalog` workflow succeeds on merge to main

Fixes workload-catalog GitHub Actions failure after PR #54 merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)