### PR TITLE
fix: add data_security_mode SINGLE_USER to enable Unity Catalog on job cluster

### DIFF
--- a/platform/databricks.yml
+++ b/platform/databricks.yml
@@ -35,6 +35,7 @@ resources:
             spark_version: "14.3.x-scala2.12"
             node_type_id: "Standard_DS3_v2"
             num_workers: 0
+            data_security_mode: SINGLE_USER
             spark_conf:
               spark.master: "local[*, 4]"
               spark.databricks.cluster.profile: "singleNode"


### PR DESCRIPTION
## Summary
- Adds `data_security_mode: SINGLE_USER` to the `new_cluster` config in `platform/databricks.yml`
- Without this setting, the cluster starts in legacy mode using `spark_catalog`, which rejects 2-part Unity Catalog namespaces

## Root Cause
The `setup_catalog_schema` job cluster was running without `data_security_mode`, defaulting to the legacy Hive metastore (`spark_catalog`). When the notebook executed `CREATE SCHEMA IF NOT EXISTS mock_prod.bronze`, Spark routed it to `spark_catalog` which requires a single-part namespace (schema name only), raising:
```
[REQUIRES_SINGLE_PART_NAMESPACE] spark_catalog requires a single-part namespace, but got `mock_prod`.`bronze`. SQLSTATE: 42K05
```

## Fix
`data_security_mode: SINGLE_USER` enables Unity Catalog on the cluster, allowing:
- `CREATE CATALOG IF NOT EXISTS mock_prod`
- `CREATE SCHEMA IF NOT EXISTS mock_prod.bronze` (catalog-qualified, 2-part namespace)

## Test plan
- [ ] `workload-catalog` workflow passes on merge to main
- [ ] All 4 DDL statements execute without error (`CREATE CATALOG` + 3× `CREATE SCHEMA`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)