### PR TITLE
fix: strip SQL comment lines before splitting to preserve CREATE CATALOG

### DIFF
--- a/platform/notebooks/00_setup_catalog_schema.py
+++ b/platform/notebooks/00_setup_catalog_schema.py
@@ -38,7 +38,8 @@ print(sql_rendered)
 
 # COMMAND ----------
 
-statements = [s.strip() for s in sql_rendered.split(";") if s.strip() and not s.strip().startswith("--")]
+sql_no_comments = "\n".join(line for line in sql_rendered.splitlines() if not line.strip().startswith("--"))
+statements = [s.strip() for s in sql_no_comments.split(";") if s.strip()]
 
 for stmt in statements:
     print(f"Executing:\n{stmt}\n")


### PR DESCRIPTION
## Summary
- Fixes `NO_SUCH_CATALOG_EXCEPTION` by correcting SQL comment-stripping logic in the notebook

## Root Cause
The `.j2` template starts with file-level `--` comments, followed by `CREATE CATALOG IF NOT EXISTS mock_prod` — all before the first `;`. When the notebook split on `;` and filtered chunks starting with `--`, the entire first chunk (comments + `CREATE CATALOG`) was silently dropped. The `CREATE SCHEMA` statements then failed because `mock_prod` never existed.

**Before:**
```python
# Drops entire first chunk because it starts with "--"
statements = [s.strip() for s in sql_rendered.split(";") if s.strip() and not s.strip().startswith("--")]
```

**After:**
```python
# Strip comment lines first, then split — CREATE CATALOG is preserved
sql_no_comments = "\n".join(line for line in sql_rendered.splitlines() if not line.strip().startswith("--"))
statements = [s.strip() for s in sql_no_comments.split(";") if s.strip()]
```

## Test plan
- [ ] `workload-catalog` passes on merge to main
- [ ] All 4 statements execute: `CREATE CATALOG mock_prod` + 3× `CREATE SCHEMA`

🤖 Generated with [Claude Code](https://claude.com/claude-code)