### PR TITLE
fix: pass MANAGED LOCATION to CREATE CATALOG to bypass missing metastore storage root

### DIFF
--- a/.github/workflows/workload-catalog.yaml
+++ b/.github/workflows/workload-catalog.yaml
@@ -47,10 +47,12 @@ jobs:
             -backend-config="container_name=workload-tfstate" \
             -backend-config="key=azure.tfstate"
 
-      - name: Capture workspace_url from workload-azure outputs
+      - name: Capture workload-azure outputs
         id: azout
         run: |
           echo "WORKSPACE_URL=$(terraform -chdir=infra/workload-azure output -raw workspace_url)" >> $GITHUB_OUTPUT
+          echo "STORAGE_ACCOUNT_NAME=$(terraform -chdir=infra/workload-azure output -raw storage_account_name)" >> $GITHUB_OUTPUT
+          echo "UC_ROOT_CONTAINER=$(terraform -chdir=infra/workload-azure output -raw uc_root_container)" >> $GITHUB_OUTPUT
 
       - name: Set DATABRICKS_HOST
         run: echo "DATABRICKS_HOST=https://${{ steps.azout.outputs.WORKSPACE_URL }}" >> $GITHUB_ENV
@@ -81,4 +83,9 @@ jobs:
 
       - name: Bundle run — setup_catalog_schema
         working-directory: platform
-        run: databricks bundle run setup_catalog_schema --target ${{ steps.target.outputs.TARGET }} --no-wait=false
+        run: |
+          databricks bundle run setup_catalog_schema \
+            --target ${{ steps.target.outputs.TARGET }} \
+            --var "storage_account_name=${{ steps.azout.outputs.STORAGE_ACCOUNT_NAME }}" \
+            --var "uc_root_container=${{ steps.azout.outputs.UC_ROOT_CONTAINER }}" \
+            --no-wait=false

--- a/platform/databricks.yml
+++ b/platform/databricks.yml
@@ -5,6 +5,12 @@ variables:
   catalog_env:
     description: "Target environment (dev|staging|prod)"
     default: dev
+  storage_account_name:
+    description: "ADLS Gen2 storage account name (from workload-azure TF output)"
+    default: ""
+  uc_root_container:
+    description: "ADLS container for UC metastore root (from workload-azure TF output)"
+    default: ""
 
 targets:
   dev:
@@ -31,6 +37,8 @@ resources:
             source: WORKSPACE
             base_parameters:
               env: "${var.catalog_env}"
+              storage_account_name: "${var.storage_account_name}"
+              uc_root_container: "${var.uc_root_container}"
           new_cluster:
             spark_version: "14.3.x-scala2.12"
             node_type_id: "Standard_DS3_v2"

--- a/platform/ddl/catalog_schema.sql.j2
+++ b/platform/ddl/catalog_schema.sql.j2
@@ -4,6 +4,7 @@
 -- Rendered by 00_setup_catalog_schema.py with env={{ env }}
 
 CREATE CATALOG IF NOT EXISTS mock_{{ env }}
+  MANAGED LOCATION 'abfss://{{ uc_root_container }}@{{ storage_account_name }}.dfs.core.windows.net/catalogs/mock_{{ env }}'
   COMMENT 'Mock data platform catalog — {{ env }} environment';
 
 CREATE SCHEMA IF NOT EXISTS mock_{{ env }}.bronze

--- a/platform/notebooks/00_setup_catalog_schema.py
+++ b/platform/notebooks/00_setup_catalog_schema.py
@@ -11,8 +11,14 @@ from jinja2 import Template
 # COMMAND ----------
 
 dbutils.widgets.text("env", "dev")
+dbutils.widgets.text("storage_account_name", "")
+dbutils.widgets.text("uc_root_container", "")
 env = dbutils.widgets.get("env")
-print(f"Target environment: {env}")
+storage_account_name = dbutils.widgets.get("storage_account_name")
+uc_root_container = dbutils.widgets.get("uc_root_container")
+print(f"Target environment   : {env}")
+print(f"Storage account      : {storage_account_name}")
+print(f"UC root container    : {uc_root_container}")
 
 # COMMAND ----------
 
@@ -32,7 +38,11 @@ print(f"Template path: {template_path}")
 with open(template_path) as f:
     raw = f.read()
 
-sql_rendered = Template(raw).render(env=env)
+sql_rendered = Template(raw).render(
+    env=env,
+    storage_account_name=storage_account_name,
+    uc_root_container=uc_root_container,
+)
 print("=== Rendered SQL ===")
 print(sql_rendered)
 


### PR DESCRIPTION
## Summary
- `CREATE CATALOG` failed with `INVALID_STATE: Metastore storage root URL does not exist`
- Root cause: the metastore's `storage_root` path (`abfss://<container>@<storage>.dfs.core.windows.net/<metastore_id>`) doesn't exist as a live ADLS path at runtime
- Fix: provide an explicit `MANAGED LOCATION` in `CREATE CATALOG` using the ADLS storage account from workload-azure Terraform outputs, bypassing the metastore root entirely

## Changes (4 files)

**`.github/workflows/workload-catalog.yaml`**
- Capture `storage_account_name` and `uc_root_container` from workload-azure TF outputs
- Pass them as `--var` overrides to `databricks bundle run`

**`platform/databricks.yml`**
- Add `storage_account_name` and `uc_root_container` bundle variables
- Thread them through to notebook `base_parameters`

**`platform/ddl/catalog_schema.sql.j2`**
- Add `MANAGED LOCATION 'abfss://{{ uc_root_container }}@{{ storage_account_name }}.dfs.core.windows.net/catalogs/mock_{{ env }}'` to `CREATE CATALOG`

**`platform/notebooks/00_setup_catalog_schema.py`**
- Accept `storage_account_name` and `uc_root_container` as widgets
- Forward them to the Jinja2 template render call

## Test plan
- [ ] `workload-catalog` passes on merge to main
- [ ] `CREATE CATALOG mock_prod MANAGED LOCATION '...'` executes without error
- [ ] 3× `CREATE SCHEMA` succeed with catalog present

🤖 Generated with [Claude Code](https://claude.com/claude-code)