### PR TITLE
fix: remove stale import block that fails when metastore is destroyed

### DIFF
--- a/docs/sessions/2026-03-06-002-issue-64-fix.md
+++ b/docs/sessions/2026-03-06-002-issue-64-fix.md
@@ -1,0 +1,51 @@
+# Session 2026-03-06-002 — Issue #64: Remove stale import block
+
+## Problem
+
+`workload-dbx` apply fails with:
+
+```
+Error: Cannot import non-existent remote object
+
+While attempting to import an existing object to "databricks_metastore.this",
+the provider detected that no object exists with the given id.
+```
+
+The import block (added in PR #63 for issue #62) tries to import the metastore
+using `var.metastore_id`. But the metastore was **destroyed** when `workload-dbx`
+was last torn down (`force_destroy = true`). There is nothing to import.
+
+## Root Cause
+
+The import block was a one-time migration fix for state drift (issue #62: metastore
+existed in Databricks account but not in Terraform state). It cannot handle the
+case where the metastore was truly deleted — which happens on every `workload-dbx`
+destroy because `force_destroy = true` on `databricks_metastore.this`.
+
+## Fix (PR #73)
+
+- Removed the `import { ... }` block from `infra/workload-dbx/main.tf`
+- Added `output "metastore_id"` so the new UUID is visible in CI Apply logs
+
+With the import block removed, Terraform will **create** a fresh metastore on
+the next apply.
+
+## Post-Apply Human Actions Required
+
+1. Find the new metastore UUID in the "Terraform Apply" step output:
+   ```
+   metastore_id = "<new-uuid>"
+   ```
+2. Update the `METASTORE_ID` GitHub Secret with the new UUID
+3. Run post-destroy grants (see `docs/runbooks/post-destroy-grants.md`):
+   - `GRANT CREATE EXTERNAL LOCATION ON METASTORE TO '<SP_client_id>';`
+   - `GRANT CREATE CATALOG ON METASTORE TO '<SP_client_id>';`
+
+## Notes on storage_root
+
+`storage_root` still uses `var.metastore_id` (the old UUID) as a path suffix for
+the initial creation. Because `ignore_changes = [storage_root]` is set, Terraform
+will not attempt to reconcile this after creation. The ADLS path will be:
+`abfss://uc-root@<storage>.dfs.core.windows.net/<old-uuid>/`
+
+This is cosmetically odd but functionally correct — it is just a directory path.

--- a/infra/workload-dbx/main.tf
+++ b/infra/workload-dbx/main.tf
@@ -34,16 +34,6 @@ locals {
 # Unity Catalog Metastore (ACCOUNT SCOPE)
 # -------------------------------------------------------------------
 
-# Import the existing metastore into state if it already exists in the Databricks account.
-# Prevents "reached the limit for metastores in region" errors caused by state drift
-# (e.g. after a destroy that removed the resource from state but not from the account).
-# Safe to leave permanently: Terraform skips the import when the resource is already in state.
-import {
-  provider = databricks.account
-  to       = databricks_metastore.this
-  id       = var.metastore_id
-}
-
 resource "databricks_metastore" "this" {
   provider = databricks.account
 
@@ -101,6 +91,17 @@ resource "databricks_external_location" "uc_root" {
   comment       = "UC root external location"
 
   depends_on = [databricks_metastore_assignment.this]
+}
+
+# -------------------------------------------------------------------
+# Outputs
+# -------------------------------------------------------------------
+
+# Expose the metastore ID so the new UUID is visible in CI Apply logs.
+# After first-time creation, update the METASTORE_ID GitHub secret with this value.
+output "metastore_id" {
+  description = "UUID of the Unity Catalog metastore created by this workspace"
+  value       = databricks_metastore.this.id
 }
 
 # Catalog and schema management is intentionally handled outside Terraform.


### PR DESCRIPTION
## Summary

- Removes the `import { ... }` block from `infra/workload-dbx/main.tf` that was added in PR #63 to fix state drift (issue #62)
- The import block assumes the metastore exists in the Databricks account, but `force_destroy = true` on `workload-dbx` destroy truly deletes it — causing `Cannot import non-existent remote object` on the next apply
- Adds `output "metastore_id"` so the new UUID is visible in the CI Apply step logs

## Root Cause

The import block was a one-time migration tool for issue #62 (state drift). It is incompatible with the destroy-recreate cycle because `force_destroy = true` deletes the metastore entirely, not just from state.

## Post-Merge Human Actions Required

After this PR merges and `workload-dbx` apply succeeds:

1. Find the new metastore UUID in the "Terraform Apply" step output: `metastore_id = "<new-uuid>"`
2. Update the `METASTORE_ID` GitHub Secret with the new UUID
3. Run post-destroy grants (see `docs/runbooks/post-destroy-grants.md`)

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)