### PR TITLE
fix: restore import block so existing metastore is imported not recreated

### DIFF
--- a/docs/sessions/2026-03-06-004-issue-64-restore-import.md
+++ b/docs/sessions/2026-03-06-004-issue-64-restore-import.md
@@ -1,0 +1,47 @@
+# Session 2026-03-06-004 — Issue #64: Restore import block (correct UUID now in secret)
+
+## What Happened
+
+PR #72 (session 002) removed the import block, believing the metastore was
+truly destroyed. This was incorrect.
+
+## Root Cause Correction
+
+The metastore `4f069ca3-af7f-4149-b0d0-525906a66fee` (name: `metastore_azure_japaneast`)
+**survived** because every previous `workload-dbx` destroy run was failing at the
+import block (METASTORE_ID secret contained extra content, not a plain UUID).
+Terraform never reached the actual destroy step — the metastore was intact in the
+Databricks account the whole time.
+
+After PR #72 removed the import block, Terraform tried to **create** a new metastore
+→ hit the 1-per-region limit:
+
+```
+Error: cannot create metastore: This account with id *** has reached the limit
+for metastores in region japaneast.
+```
+
+## Fix (this PR)
+
+Restored the import block with an updated comment that correctly explains the
+design: the metastore is account-scoped and persists across workspace destroy/
+recreate cycles. The METASTORE_ID secret is now set to the correct bare UUID
+(`4f069ca3-af7f-4149-b0d0-525906a66fee`), so the import will succeed.
+
+## Correct Mental Model
+
+| Scenario | Import block behaviour |
+|----------|-----------------------|
+| Metastore in state AND in account | No-op (skipped by Terraform) |
+| Metastore NOT in state, IS in account | Imports into state ✅ (designed for this) |
+| Metastore NOT in state, NOT in account | Fails ❌ (must remove block and create fresh) |
+
+In this project the metastore is never truly absent from the account unless:
+- A successful `terraform destroy` ran with `force_destroy = true`
+- The metastore was deleted manually from the Databricks Account Console
+
+## Post-Merge
+
+No additional human action required beyond what is already set:
+- `METASTORE_ID` secret = `4f069ca3-af7f-4149-b0d0-525906a66fee` ✅
+- After apply succeeds, run post-destroy grants (see runbook)

--- a/infra/workload-dbx/main.tf
+++ b/infra/workload-dbx/main.tf
@@ -34,6 +34,19 @@ locals {
 # Unity Catalog Metastore (ACCOUNT SCOPE)
 # -------------------------------------------------------------------
 
+# Import the existing metastore into Terraform state.
+# The UC metastore is account-scoped and is NOT destroyed by workload-dbx
+# destroy — it persists across workspace destroy/recreate cycles.
+# This import block ensures Terraform manages the pre-existing metastore
+# rather than attempting to create a new one (which would hit the
+# 1-per-region limit). Safe to leave permanently: Terraform skips the
+# import when the resource is already in state.
+import {
+  provider = databricks.account
+  to       = databricks_metastore.this
+  id       = var.metastore_id
+}
+
 resource "databricks_metastore" "this" {
   provider = databricks.account
 


### PR DESCRIPTION
## Summary

- Restores the `import { ... }` block that PR #72 removed
- The metastore `4f069ca3-af7f-4149-b0d0-525906a66fee` still exists in the Databricks account — it survived previous destroy runs because those runs were always failing at the import step (bad UUID in secret), never reaching the actual Terraform destroy
- With `METASTORE_ID` now set to the correct bare UUID, the import block will successfully pull the existing metastore into state
- Updated the comment to correctly describe the design: metastore is account-scoped and persists across workspace destroy/recreate cycles

## Why PR #72 Was Wrong

PR #72 assumed the metastore was truly destroyed. It was not. Every previous `workload-dbx` destroy failed at the import step before Terraform could execute the destroy. Removing the import block caused Terraform to try creating a new metastore, hitting the 1-per-region limit:

```
Error: cannot create metastore: This account has reached the limit for metastores in region japaneast.
```

## Import Block Behaviour Table

| State | Import block result |
|-------|---------------------|
| Metastore in state AND in account | No-op (skipped) |
| Metastore NOT in state, IS in account | Imports ✅ |
| Metastore NOT in state, NOT in account | Fails ❌ |

## No Additional Human Action Required

`METASTORE_ID` secret is already set to `4f069ca3-af7f-4149-b0d0-525906a66fee`. After this merges and apply succeeds, run post-destroy grants per the runbook.

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)