### PR TITLE
docs: close issue #64 and document Account ID vs Metastore ID URL pitfall

### DIFF
--- a/.github/workflows/workload-dbx.yaml
+++ b/.github/workflows/workload-dbx.yaml
@@ -82,27 +82,6 @@ jobs:
             -backend-config="container_name=$TFSTATE_CONTAINER" \
             -backend-config="key=$TFSTATE_KEY"
 
-      # Temporary diagnostic step — remove once issue #64 is fully resolved.
-      # Lists all metastores visible in the Databricks account (confirms UUID and name).
-      # Also prints METASTORE_ID character count: a bare UUID is exactly 36 chars.
-      # If the count differs, the secret has extra whitespace or content.
-      - name: Diagnose — list account metastores and verify METASTORE_ID length
-        run: |
-          TOKEN=$(az account get-access-token \
-            --resource 2ff814a6-3304-4ab8-85cb-cd0e6f879c1d \
-            --query accessToken -o tsv)
-
-          echo "=== Metastores in Databricks account ==="
-          curl -sf \
-            -H "Authorization: Bearer $TOKEN" \
-            "https://accounts.azuredatabricks.net/api/2.0/accounts/${{ secrets.DATABRICKS_ACCOUNT_ID }}/metastores" \
-            | jq -r '.metastores[]? | "  id=\(.metastore_id)  name=\(.name)"' \
-            || echo "  (API error or no metastores)"
-
-          echo ""
-          echo "=== METASTORE_ID secret character count (bare UUID = 36) ==="
-          printf '%s' "${{ secrets.METASTORE_ID }}" | wc -c
-
       - name: Terraform Plan (PR)
         if: github.event_name == 'pull_request'
         run: |

--- a/docs/runbooks/destroy-recreate.md
+++ b/docs/runbooks/destroy-recreate.md
@@ -29,6 +29,11 @@ Guardrails and the tfstate backend are not touched — they persist across cycle
 3. **Update `METASTORE_ID` GitHub secret** — copy the new UUID from the `metastore_id` output in the CI Apply logs
    - GitHub → Settings → Secrets and variables → Actions → `METASTORE_ID`
    - A fresh metastore is created on every recreate; the UUID always changes
+   - **Pitfall:** The Databricks Account Console metastore detail URL looks like:
+     `https://accounts.azuredatabricks.net/data/<METASTORE_ID>/configurations?account_id=<ACCOUNT_ID>`
+     The **Metastore ID** is the path segment (before `/configurations`).
+     The `account_id` query parameter is the **Databricks Account ID** — a different value.
+     Copying the wrong one is a common mistake that causes `Cannot import non-existent remote object`.
 4. Run post-destroy grants — see [post-destroy-grants.md](./post-destroy-grants.md)
 5. Trigger `workload-catalog` — creates Catalog and Schemas via Jinja2 + SQL notebook
 
@@ -56,7 +61,9 @@ Error: cannot create storage credential: Storage Credential 'uc-mi-credential' a
 
 - Guardrails (`guardrails.yaml`) and the tfstate Storage Account (`bootstrap.yaml`) are never
   destroyed in this cycle — they persist and remain valid after recreate.
-- The Metastore is destroyed and recreated by `workload-dbx` destroy/apply. This is expected;
-  `force_destroy = true` on the metastore ensures notebook-created catalogs are cascade-deleted.
-- After recreate, the `METASTORE_ID` GitHub secret **must** be updated with the new UUID from the
-  `workload-dbx` Apply output. The metastore UUID changes on every destroy/recreate cycle.
+- The Metastore is destroyed by a successful `workload-dbx` destroy (`force_destroy = true` ensures
+  notebook-created catalogs are cascade-deleted). If a destroy run fails mid-way, the metastore may
+  survive — the import block in Terraform handles re-importing it on the next apply.
+- After recreate, the `METASTORE_ID` GitHub secret **must** be updated with the UUID from the
+  `workload-dbx` Apply output (`metastore_id` output). The UUID changes when a new metastore is
+  created, but stays the same if the previous one was imported (survived a failed destroy).

--- a/docs/sessions/2026-03-06-005-issue-64-resolved.md
+++ b/docs/sessions/2026-03-06-005-issue-64-resolved.md
@@ -1,0 +1,46 @@
+# Session 2026-03-06-005 — Issue #64: Resolved
+
+## Summary
+
+Issue #64 is fully resolved. `workload-dbx` apply succeeded:
+`Apply complete! Resources: 1 imported, 3 added, 1 changed, 0 destroyed.`
+
+## Actual Root Cause
+
+The `METASTORE_ID` GitHub secret contained the **Databricks Account ID**, not the **Metastore ID**.
+These are two different UUIDs visible on the same URL in the Account Console:
+
+```
+https://accounts.azuredatabricks.net/data/<METASTORE_ID>/configurations?account_id=<ACCOUNT_ID>
+```
+
+- The **Metastore ID** is the path segment before `/configurations`
+- The **Account ID** is the `account_id` query parameter
+
+Copying the `account_id` query parameter instead of the path segment is easy to do — both are
+UUIDs and look identical in format. The secret had the correct 36-character length, so format
+validation passed, but the value referred to the wrong object entirely.
+
+## Investigation Path
+
+1. First attempt (PR #72): removed the import block — wrong fix; caused "reached region limit"
+   error because the metastore still existed (previous destroy runs had all failed before
+   reaching the metastore deletion step)
+2. Second attempt (PR #74): restored the import block — still failed; UUID in secret was wrong
+3. Diagnostic step (PR #75): listed actual metastores via REST API → revealed the correct UUID
+4. User confirmed the URL structure mistake — updated the secret with the correct UUID
+5. Apply succeeded on the next run
+
+## What Changed (code)
+
+- `infra/workload-dbx/main.tf`: import block restored with corrected comment (PR #74)
+- `infra/workload-dbx/main.tf`: `output "metastore_id"` added to surface UUID in CI logs (PR #72)
+- `.github/workflows/workload-dbx.yaml`: diagnostic step removed (this PR)
+- `docs/runbooks/destroy-recreate.md`: pitfall note added about Account Console URL structure
+
+## Lessons Learned
+
+- When `METASTORE_ID` needs to be set: use the `metastore_id` output from the `workload-dbx`
+  Apply step — do not copy from the Account Console URL manually.
+- The import block is the right design: it handles the case where a prior destroy failed and
+  the metastore survived. It is safe to leave permanently.

--- a/docs/status.md
+++ b/docs/status.md
@@ -12,7 +12,6 @@ opened, closed, or changed severity during the session.
 |-------|----------|-------|-------|
 | [#40](https://github.com/nobhri/azure-dbx-mock-platform/issues/40) | MEDIUM | OIDC not configured for pull_request subject | PR CI always fails Azure login. Fix: add `pull_request` federated credential in Entra ID. No code change needed. |
 | [#53](https://github.com/nobhri/azure-dbx-mock-platform/issues/53) | LOW | Document GRANT CREATE CATALOG prerequisite | Update GETTING_STARTED.md and post-destroy-grants runbook. Partially addressed by `docs/runbooks/post-destroy-grants.md`. |
-| [#64](https://github.com/nobhri/azure-dbx-mock-platform/issues/64) | HIGH | METASTORE_ID secret not a plain UUID | Fix: remove stale import block from `workload-dbx/main.tf` + add `metastore_id` output (code fix PR pending). Post-apply human action: copy new UUID from CI Apply output and update `METASTORE_ID` GitHub secret. |
 | [#68](https://github.com/nobhri/azure-dbx-mock-platform/issues/68) | MEDIUM | workload-catalog fails when workload-dbx external location not present | Infrastructure ordering dependency. `workload-dbx` must complete before `workload-catalog`. Documented in `docs/runbooks/destroy-recreate.md`. |
 
 ---
@@ -23,7 +22,6 @@ These require direct human action in Azure, GitHub, or Databricks — cannot be 
 
 | Action | Priority | Where |
 |--------|----------|-------|
-| After `workload-dbx` apply: update `METASTORE_ID` GitHub secret with new UUID from CI Apply output (`metastore_id` output) | HIGH | GitHub → Settings → Secrets |
 | Add OIDC federated credential for `pull_request` subject | MEDIUM | Entra ID → App Registration → Federated credentials |
 | After each destroy/recreate: run post-destroy grants | REQUIRED | Databricks SQL warehouse — see [runbook](runbooks/post-destroy-grants.md) |
 
@@ -33,6 +31,7 @@ These require direct human action in Azure, GitHub, or Databricks — cannot be 
 
 | Issue | Title | Closed by |
 |-------|-------|-----------|
+| [#64](https://github.com/nobhri/azure-dbx-mock-platform/issues/64) | METASTORE_ID secret had wrong UUID (account ID copied instead of metastore ID) | PRs #72 #74 #75 — import block restored; correct UUID set; apply succeeded |
 | [#62](https://github.com/nobhri/azure-dbx-mock-platform/issues/62) | Metastore state drift (reached region limit) | PR #63 — import block added |
 | [#61](https://github.com/nobhri/azure-dbx-mock-platform/issues/61) | bundle deploy missing --var flags → empty base_parameters | PR #65 merged |
 | [#52](https://github.com/nobhri/azure-dbx-mock-platform/issues/52) | Add catalog/schema DDL layer via Jinja2 + Asset Bundle | PR #54 merged |
@@ -57,7 +56,7 @@ These require direct human action in Azure, GitHub, or Databricks — cannot be 
 | Component | State |
 |-----------|-------|
 | workload-azure | Destroyed (cost-saving) |
-| workload-dbx | Destroyed (cost-saving) |
+| workload-dbx | Deployed |
 | workload-catalog | Not applied (depends on workload-dbx) |
 | guardrails | Deployed |
 | tfstate backend | Deployed |


### PR DESCRIPTION
## Summary

Cleanup and documentation after issue #64 was resolved.

- Removes the temporary diagnostic step from `workload-dbx.yaml` (added in PR #75)
- Closes #64 in `status.md`; updates architecture state (`workload-dbx: Deployed`)
- Removes the stale `METASTORE_ID` pending human action from `status.md`
- Adds a pitfall note to `docs/runbooks/destroy-recreate.md` documenting the root cause

## Root Cause (for the record)

The `METASTORE_ID` secret had the **Databricks Account ID** in it, not the Metastore ID. Both are UUIDs. The Account Console URL makes this easy to confuse:

```
https://accounts.azuredatabricks.net/data/<METASTORE_ID>/configurations?account_id=<ACCOUNT_ID>
```

The Metastore ID is in the **path**; the Account ID is the **query parameter**. The runbook now calls this out explicitly.

## Going forward

Always copy `METASTORE_ID` from the `metastore_id` output in the CI Apply logs — not from the Account Console URL.

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)