### PR TITLE
fix: add preflight check for issue #68 catalog ordering dependency

### DIFF
--- a/.github/workflows/workload-catalog.yaml
+++ b/.github/workflows/workload-catalog.yaml
@@ -77,6 +77,18 @@ jobs:
             echo "TARGET=${{ inputs.target }}" >> $GITHUB_OUTPUT
           fi
 
+      - name: Preflight — verify UC external location exists
+        run: |
+          COUNT=$(databricks external-locations list --output json \
+            | jq '[.[] | select(.name == "uc-root-location")] | length')
+          if [ "$COUNT" -eq 0 ]; then
+            echo "::error::UC external location 'uc-root-location' not found."
+            echo "  workload-dbx must be applied before workload-catalog."
+            echo "  See docs/runbooks/destroy-recreate.md for the required deployment order."
+            exit 1
+          fi
+          echo "Preflight passed: external location 'uc-root-location' found."
+
       - name: Bundle deploy
         working-directory: platform
         run: |

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -137,7 +137,14 @@ METASTORE_ID=<your Unity Catalog metastore UUID>
 - Deploys: Unity Catalog Metastore, Workspace assignment, Storage Credential, External Location, Catalog, Schemas, Grants
 - State: `workload-tfstate/dbx.tfstate`
 
-### 5. Destroy and Recreate (optional)
+### 5. Workload — Catalog Layer
+
+- Trigger `workload-catalog.yaml`
+- Deploys: Unity Catalog catalog and schemas via Jinja2 + Python notebook (Asset Bundle)
+- **Must run after `workload-dbx` apply** — requires the External Location created in step 4
+- If the External Location is missing, the workflow fails with `EXTERNAL_LOCATION_DOES_NOT_EXIST` before the bundle even runs (see Common Pitfalls)
+
+### 6. Destroy and Recreate (optional)
 
 For the full destroy/recreate procedure, including mandatory ordering, orphaned UC object recovery,
 and required post-recreate grants, see:
@@ -171,6 +178,7 @@ and required post-recreate grants, see:
   - Unity Catalog root storage Storage Account
 - `Storage Credential 'uc-mi-credential' already exists` on workload-dbx apply → UC objects orphaned from a previous destroy (wrong order) — follow [Orphaned UC objects recovery](#orphaned-uc-objects-recovery)
 - `workload-dbx` apply fails after recreate with permission errors → re-grant `CREATE EXTERNAL LOCATION ON METASTORE` as metastore admin — see [docs/runbooks/post-destroy-grants.md](docs/runbooks/post-destroy-grants.md)
+- `workload-catalog` fails with `EXTERNAL_LOCATION_DOES_NOT_EXIST` → `workload-dbx` has not been applied yet; apply it first (step 4 must precede step 5)
 - **Do not run `terraform` from the repo root** — always use `-chdir=infra/<module>` (or let CI do it). Running terraform at the root creates a local `terraform.tfstate` in the repo root that is out of sync with the remote backend. The file is excluded by `.gitignore` but indicates an accidental manual run outside the intended module directory.
 
 ---

--- a/docs/sessions/2026-03-06-006-issue-68-catalog-preflight.md
+++ b/docs/sessions/2026-03-06-006-issue-68-catalog-preflight.md
@@ -1,0 +1,32 @@
+# Session 2026-03-06-006 — Issue #68: workload-catalog preflight check
+
+## Summary
+
+Added a preflight check to `workload-catalog.yaml` that fails fast with a clear error when
+the UC External Location (`uc-root-location`) is missing. Also documented the
+`workload-catalog` deployment step and its dependency in `GETTING_STARTED.md`.
+
+## Changes
+
+- `.github/workflows/workload-catalog.yaml`: added "Preflight — verify UC external location
+  exists" step before `bundle deploy`; uses `databricks external-locations list --output json`
+  + `jq` to check for `uc-root-location`; exits with `::error::` annotation if not found
+- `GETTING_STARTED.md`: added step 5 (Workload — Catalog Layer) to Deployment Steps with
+  explicit prerequisite note; added `EXTERNAL_LOCATION_DOES_NOT_EXIST` entry to Common Pitfalls
+
+## Root Cause (Issue #68)
+
+`CREATE CATALOG ... MANAGED LOCATION` requires a UC External Location covering the target
+ABFSS path. `uc-root-location` is created by `workload-dbx` Terraform. Without it, the
+notebook fails with `AnalysisException: EXTERNAL_LOCATION_DOES_NOT_EXIST`. The underlying
+cause is not a catalog bug — it is a missing infrastructure prerequisite.
+
+## Why This Fix
+
+Without the preflight, the error surfaces deep inside the notebook run as a SQL
+`AnalysisException`, which is hard to diagnose. The preflight surfaces it as a workflow step
+failure with an explicit message pointing to the runbook, before any bundle deploy occurs.
+
+## PR
+
+PR #78 (`fix/68-catalog-preflight`)

--- a/docs/status.md
+++ b/docs/status.md
@@ -12,7 +12,6 @@ opened, closed, or changed severity during the session.
 |-------|----------|-------|-------|
 | [#40](https://github.com/nobhri/azure-dbx-mock-platform/issues/40) | MEDIUM | OIDC not configured for pull_request subject | PR CI always fails Azure login. Fix: add `pull_request` federated credential in Entra ID. No code change needed. |
 | [#53](https://github.com/nobhri/azure-dbx-mock-platform/issues/53) | LOW | Document GRANT CREATE CATALOG prerequisite | Update GETTING_STARTED.md and post-destroy-grants runbook. Partially addressed by `docs/runbooks/post-destroy-grants.md`. |
-| [#68](https://github.com/nobhri/azure-dbx-mock-platform/issues/68) | MEDIUM | workload-catalog fails when workload-dbx external location not present | Infrastructure ordering dependency. `workload-dbx` must complete before `workload-catalog`. Documented in `docs/runbooks/destroy-recreate.md`. |
 
 ---
 
@@ -31,6 +30,7 @@ These require direct human action in Azure, GitHub, or Databricks — cannot be 
 
 | Issue | Title | Closed by |
 |-------|-------|-----------|
+| [#68](https://github.com/nobhri/azure-dbx-mock-platform/issues/68) | workload-catalog fails when workload-dbx external location not present | PR #78 — preflight check added to workflow; GETTING_STARTED.md updated |
 | [#64](https://github.com/nobhri/azure-dbx-mock-platform/issues/64) | METASTORE_ID secret had wrong UUID (account ID copied instead of metastore ID) | PRs #72 #74 #75 — import block restored; correct UUID set; apply succeeded |
 | [#62](https://github.com/nobhri/azure-dbx-mock-platform/issues/62) | Metastore state drift (reached region limit) | PR #63 — import block added |
 | [#61](https://github.com/nobhri/azure-dbx-mock-platform/issues/61) | bundle deploy missing --var flags → empty base_parameters | PR #65 merged |


### PR DESCRIPTION
## Summary

- `workload-catalog.yaml`: new preflight step before `bundle deploy` — uses `databricks external-locations list` to verify `uc-root-location` exists; exits with a clear `::error::` annotation if missing, pointing to the runbook
- `GETTING_STARTED.md`: added step 5 (Workload — Catalog Layer) to Deployment Steps with explicit prerequisite; added `EXTERNAL_LOCATION_DOES_NOT_EXIST` to Common Pitfalls
- `docs/status.md`: closed issue #68

## Why

Without the preflight, the failure surfaces as a SQL `AnalysisException` deep in the notebook run — hard to diagnose. With it, the workflow fails at step "Preflight — verify UC external location exists" with a human-readable message before any bundle is deployed.

## Test plan
- [ ] Trigger `workload-catalog.yaml` when `workload-dbx` has NOT been applied → should fail at preflight step with `::error::` annotation
- [ ] Trigger `workload-catalog.yaml` when `workload-dbx` IS applied and `uc-root-location` exists → preflight passes, bundle deploy proceeds normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)