### PR TITLE
fix: replace static import block with dynamic metastore discovery (#80)

### DIFF
--- a/.github/workflows/workload-dbx.yaml
+++ b/.github/workflows/workload-dbx.yaml
@@ -82,6 +82,42 @@ jobs:
             -backend-config="container_name=$TFSTATE_CONTAINER" \
             -backend-config="key=$TFSTATE_KEY"
 
+      # Discover and import an existing metastore into Terraform state if needed.
+      # Handles the "failed-destroy recovery" case: if a previous destroy run failed
+      # mid-way, the metastore may still exist in the account but no longer be in state.
+      # If the metastore was successfully destroyed, this step is a no-op and Terraform
+      # will create a fresh one on apply.
+      - name: Import metastore if it exists but not in state
+        if: inputs.destroy != true
+        run: |
+          if terraform -chdir=infra/workload-dbx state show databricks_metastore.this > /dev/null 2>&1; then
+            echo "Metastore already in Terraform state — skipping import"
+            exit 0
+          fi
+          TOKEN=$(az account get-access-token \
+            --resource 2ff814a6-3304-4ab8-85cb-cd0e6f879c1d \
+            --query accessToken -o tsv)
+          EXISTING_ID=$(curl -sf \
+            -H "Authorization: Bearer $TOKEN" \
+            "https://accounts.azuredatabricks.net/api/2.0/accounts/${{ secrets.DATABRICKS_ACCOUNT_ID }}/metastores" \
+            | jq -r '.metastores[]? | .metastore_id' | head -1)
+          if [ -z "$EXISTING_ID" ]; then
+            echo "No existing metastore found — Terraform will create a fresh one"
+            exit 0
+          fi
+          echo "Found existing metastore $EXISTING_ID — importing into Terraform state"
+          terraform -chdir=infra/workload-dbx import \
+            -var="subscription_id=${{ secrets.AZURE_SUBSCRIPTION_ID }}" \
+            -var="azure_tenant_id=${{ secrets.AZURE_TENANT_ID }}" \
+            -var="resource_group_name=$RG_NAME" \
+            -var="databricks_account_id=${{ secrets.DATABRICKS_ACCOUNT_ID }}" \
+            -var="azure_workspace_resource_id=${{ steps.azout.outputs.WORKSPACE_RESOURCE_ID }}" \
+            -var="workspace_name=${{ steps.azout.outputs.WORKSPACE_NAME }}" \
+            -var="access_connector_id=${{ steps.azout.outputs.ACCESS_CONNECTOR_ID }}" \
+            -var="storage_account_name=${{ steps.azout.outputs.STORAGE_ACCOUNT_NAME }}" \
+            -var="uc_root_container=${{ steps.azout.outputs.UC_ROOT_CONTAINER }}" \
+            databricks_metastore.this "$EXISTING_ID"
+
       - name: Terraform Plan (PR)
         if: github.event_name == 'pull_request'
         run: |
@@ -90,7 +126,6 @@ jobs:
             -var="azure_tenant_id=${{ secrets.AZURE_TENANT_ID }}" \
             -var="resource_group_name=$RG_NAME" \
             -var="databricks_account_id=${{ secrets.DATABRICKS_ACCOUNT_ID }}" \
-            -var="metastore_id=${{ secrets.METASTORE_ID }}" \
             -var="azure_workspace_resource_id=${{ steps.azout.outputs.WORKSPACE_RESOURCE_ID }}" \
             -var="workspace_name=${{ steps.azout.outputs.WORKSPACE_NAME }}" \
             -var="access_connector_id=${{ steps.azout.outputs.ACCESS_CONNECTOR_ID }}" \
@@ -106,7 +141,6 @@ jobs:
             -var="azure_tenant_id=${{ secrets.AZURE_TENANT_ID }}" \
             -var="resource_group_name=$RG_NAME" \
             -var="databricks_account_id=${{ secrets.DATABRICKS_ACCOUNT_ID }}" \
-            -var="metastore_id=${{ secrets.METASTORE_ID }}" \
             -var="azure_workspace_resource_id=${{ steps.azout.outputs.WORKSPACE_RESOURCE_ID }}" \
             -var="workspace_name=${{ steps.azout.outputs.WORKSPACE_NAME }}" \
             -var="access_connector_id=${{ steps.azout.outputs.ACCESS_CONNECTOR_ID }}" \
@@ -121,7 +155,6 @@ jobs:
             -var="azure_tenant_id=${{ secrets.AZURE_TENANT_ID }}" \
             -var="resource_group_name=$RG_NAME" \
             -var="databricks_account_id=${{ secrets.DATABRICKS_ACCOUNT_ID }}" \
-            -var="metastore_id=${{ secrets.METASTORE_ID }}" \
             -var="azure_workspace_resource_id=${{ steps.azout.outputs.WORKSPACE_RESOURCE_ID }}" \
             -var="workspace_name=${{ steps.azout.outputs.WORKSPACE_NAME }}" \
             -var="access_connector_id=${{ steps.azout.outputs.ACCESS_CONNECTOR_ID }}" \

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -18,7 +18,6 @@
 | `AZURE_CLIENT_ID` | App registration client ID (created below) |
 | `TFSTATE_SA_UNIQ` | Short unique suffix for state Storage Account name |
 | `DATABRICKS_ACCOUNT_ID` | Databricks Account ID (for Unity Catalog setup) |
-| `METASTORE_ID` | UUID of the existing Unity Catalog metastore |
 
 ---
 

--- a/docs/runbooks/destroy-recreate.md
+++ b/docs/runbooks/destroy-recreate.md
@@ -26,16 +26,10 @@ Guardrails and the tfstate backend are not touched — they persist across cycle
 2. Trigger `workload-dbx.yaml` (no destroy flag)
    - Provisions: UC Metastore, Workspace assignment, Storage Credential, External Location
    - **Must complete before workload-catalog** — External Location created here is required by catalog
-3. **Update `METASTORE_ID` GitHub secret** — copy the new UUID from the `metastore_id` output in the CI Apply logs
-   - GitHub → Settings → Secrets and variables → Actions → `METASTORE_ID`
-   - A fresh metastore is created on every recreate; the UUID always changes
-   - **Pitfall:** The Databricks Account Console metastore detail URL looks like:
-     `https://accounts.azuredatabricks.net/data/<METASTORE_ID>/configurations?account_id=<ACCOUNT_ID>`
-     The **Metastore ID** is the path segment (before `/configurations`).
-     The `account_id` query parameter is the **Databricks Account ID** — a different value.
-     Copying the wrong one is a common mistake that causes `Cannot import non-existent remote object`.
-4. Run post-destroy grants — see [post-destroy-grants.md](./post-destroy-grants.md)
-5. Trigger `workload-catalog` — creates Catalog and Schemas via Jinja2 + SQL notebook
+   - The CI workflow auto-discovers and imports the metastore if one already exists in the account
+     (handles failed-destroy recovery). No manual UUID management required.
+3. Run post-destroy grants — see [post-destroy-grants.md](./post-destroy-grants.md)
+4. Trigger `workload-catalog` — creates Catalog and Schemas via Jinja2 + SQL notebook
 
 ---
 
@@ -63,7 +57,6 @@ Error: cannot create storage credential: Storage Credential 'uc-mi-credential' a
   destroyed in this cycle — they persist and remain valid after recreate.
 - The Metastore is destroyed by a successful `workload-dbx` destroy (`force_destroy = true` ensures
   notebook-created catalogs are cascade-deleted). If a destroy run fails mid-way, the metastore may
-  survive — the import block in Terraform handles re-importing it on the next apply.
-- After recreate, the `METASTORE_ID` GitHub secret **must** be updated with the UUID from the
-  `workload-dbx` Apply output (`metastore_id` output). The UUID changes when a new metastore is
-  created, but stays the same if the previous one was imported (survived a failed destroy).
+  survive — the CI workflow detects this and auto-imports it on the next apply via the Databricks
+  Account REST API (no manual UUID tracking required).
+- The `METASTORE_ID` GitHub secret is no longer used and can be removed.

--- a/docs/sessions/2026-03-06-007-issue-80-dynamic-metastore-import.md
+++ b/docs/sessions/2026-03-06-007-issue-80-dynamic-metastore-import.md
@@ -1,0 +1,50 @@
+# Session 2026-03-06-007 — Issue #80: Replace static import block with dynamic CI discovery
+
+## Summary
+
+Replaced the static `import {}` block in `workload-dbx/main.tf` with a dynamic
+"Import metastore if it exists but not in state" CI step. Also removed the
+`METASTORE_ID` GitHub secret dependency and fixed the preflight bug in
+`workload-catalog.yaml`.
+
+## Root Cause (Issue #80)
+
+The first-ever successful `workload-dbx` destroy (after issue #64 was fixed with the
+correct UUID) deleted the metastore. On the next apply, the static import block tried
+to import using the old `METASTORE_ID` UUID — which no longer existed.
+
+The import block design assumed the metastore always survived a destroy run. This was
+true while #64 was unresolved (bad UUID → destroy always failed at the import step).
+Now that the correct UUID is in use, destroy can succeed and actually delete the metastore.
+
+## Root Cause (Preflight Bug — discovered in same session)
+
+`databricks external-locations list` returned an error to stderr when no metastore
+was assigned. stdout was empty → jq produced no output → `COUNT` was `""` →
+`[ "" -eq 0 ]` returned exit 2 (`integer expression expected`). In bash `if` context,
+exit 2 is treated as "false" → body skipped → "Preflight passed" printed despite failure.
+
+## What Changed
+
+- `infra/workload-dbx/main.tf`: removed static `import {}` block; changed `storage_root`
+  to use container root (no longer depends on metastore UUID path suffix)
+- `infra/workload-dbx/variables.tf`: removed `metastore_id` variable
+- `.github/workflows/workload-dbx.yaml`: removed `-var="metastore_id=..."` from all three
+  terraform steps; added "Import metastore if it exists but not in state" step after init
+- `.github/workflows/workload-catalog.yaml`: fixed preflight to capture CLI exit code
+  explicitly (`if ! RAW=$(...)`) so CLI errors are treated as preflight failures
+- `docs/runbooks/destroy-recreate.md`: removed METASTORE_ID update step from recreate
+  procedure; updated Notes section
+- `GETTING_STARTED.md`: removed `METASTORE_ID` from required secrets table
+
+## Dynamic Import Step Logic
+
+1. If `databricks_metastore.this` is already in Terraform state → skip (no-op)
+2. Call `GET /api/2.0/accounts/<account_id>/metastores` via Azure-issued Bearer token
+3. If a metastore is found → `terraform import databricks_metastore.this <uuid>`
+4. If no metastore found → no-op (Terraform will create fresh on apply)
+
+## PRs
+
+- PR #79 (`fix/68-catalog-preflight`) — includes the preflight bug fix (second commit)
+- PR #81 (`fix/80-dynamic-metastore-import`) — this PR

--- a/docs/status.md
+++ b/docs/status.md
@@ -12,6 +12,7 @@ opened, closed, or changed severity during the session.
 |-------|----------|-------|-------|
 | [#40](https://github.com/nobhri/azure-dbx-mock-platform/issues/40) | MEDIUM | OIDC not configured for pull_request subject | PR CI always fails Azure login. Fix: add `pull_request` federated credential in Entra ID. No code change needed. |
 | [#53](https://github.com/nobhri/azure-dbx-mock-platform/issues/53) | LOW | Document GRANT CREATE CATALOG prerequisite | Update GETTING_STARTED.md and post-destroy-grants runbook. Partially addressed by `docs/runbooks/post-destroy-grants.md`. |
+| [#80](https://github.com/nobhri/azure-dbx-mock-platform/issues/80) | HIGH | workload-dbx apply fails after successful destroy: static import block uses stale METASTORE_ID | Replace static `import {}` block with dynamic CI discovery step; remove `METASTORE_ID` secret dependency. Fix: PR #81. |
 
 ---
 
@@ -56,7 +57,7 @@ These require direct human action in Azure, GitHub, or Databricks — cannot be 
 | Component | State |
 |-----------|-------|
 | workload-azure | Destroyed (cost-saving) |
-| workload-dbx | Deployed |
+| workload-dbx | Destroyed (cost-saving) |
 | workload-catalog | Not applied (depends on workload-dbx) |
 | guardrails | Deployed |
 | tfstate backend | Deployed |

--- a/infra/workload-dbx/main.tf
+++ b/infra/workload-dbx/main.tf
@@ -34,25 +34,17 @@ locals {
 # Unity Catalog Metastore (ACCOUNT SCOPE)
 # -------------------------------------------------------------------
 
-# Import the existing metastore into Terraform state.
-# The UC metastore is account-scoped and is NOT destroyed by workload-dbx
-# destroy — it persists across workspace destroy/recreate cycles.
-# This import block ensures Terraform manages the pre-existing metastore
-# rather than attempting to create a new one (which would hit the
-# 1-per-region limit). Safe to leave permanently: Terraform skips the
-# import when the resource is already in state.
-import {
-  provider = databricks.account
-  to       = databricks_metastore.this
-  id       = var.metastore_id
-}
+# No static import block — the CI workflow handles import dynamically.
+# See workload-dbx.yaml: "Import metastore if it exists but not in state".
+# This handles both scenarios:
+#   - Clean recreate (metastore was successfully destroyed): Terraform creates fresh.
+#   - Failed-destroy recovery (metastore survived): CI discovers UUID via API and imports.
 
 resource "databricks_metastore" "this" {
   provider = databricks.account
 
-  name = "mvp-metastore"
-  # storage_root = local.storage_root_abfss
-  storage_root = "abfss://${var.uc_root_container}@${var.storage_account_name}.dfs.core.windows.net/${var.metastore_id}"
+  name         = "mvp-metastore"
+  storage_root = "abfss://${var.uc_root_container}@${var.storage_account_name}.dfs.core.windows.net/"
   # force_destroy allows Terraform destroy to cascade-delete all UC objects
   # (catalogs, schemas, storage credentials) even when not managed by Terraform
   # (e.g. catalog/schema created by Jinja2 notebook — see ADR-001).

--- a/infra/workload-dbx/variables.tf
+++ b/infra/workload-dbx/variables.tf
@@ -50,11 +50,6 @@ variable "uc_root_container" {
   default     = "uc-root"
 }
 
-variable "metastore_id" {
-  description = "UUID of the existing Unity Catalog metastore (used as the storage_root path suffix)"
-  type        = string
-}
-
 # variable "catalog_name" {
 #   description = "Name of the catalog to create under the metastore"
 #   type        = string


### PR DESCRIPTION
## Summary

- `infra/workload-dbx/main.tf`: removed static `import {}` block; `storage_root` no longer uses metastore UUID as a path suffix
- `infra/workload-dbx/variables.tf`: removed `metastore_id` variable (no longer needed)
- `workload-dbx.yaml`: removed `-var="metastore_id=..."` from all three terraform steps; added "Import metastore if it exists but not in state" step after `terraform init`
- `docs/runbooks/destroy-recreate.md`: removed manual METASTORE_ID update step from recreate procedure
- `GETTING_STARTED.md`: removed `METASTORE_ID` from required secrets table

## Root Cause

After the first-ever successful `workload-dbx` destroy (enabled by issue #64 fix), the metastore was actually deleted. The next apply's static `import {}` block tried to import using the old UUID from `METASTORE_ID` secret — which no longer existed:

```
Error: Cannot import non-existent remote object
```

The import block design assumed the metastore always survived a destroy. That was true while #64 was unresolved (bad UUID → import always failed → destroy never reached the metastore deletion step). Now that the correct UUID is in use, destroy succeeds and deletes the metastore.

## Dynamic Import Step Logic

```
1. terraform state show databricks_metastore.this → already in state? skip.
2. GET /api/2.0/accounts/<id>/metastores via Azure Bearer token → find existing metastore
3. Found → terraform import databricks_metastore.this <discovered-uuid>
4. Not found → no-op (Terraform creates fresh on apply)
```

No manual `METASTORE_ID` secret management required. Works in both scenarios:
- **Clean recreate** (metastore destroyed): creates fresh ✅
- **Failed-destroy recovery** (metastore survived): auto-imports ✅

## Test plan
- [ ] Trigger `workload-dbx.yaml` (no destroy) when no metastore exists → "No existing metastore found — Terraform will create a fresh one" → apply creates metastore ✅
- [ ] Trigger `workload-dbx.yaml` (no destroy) when metastore exists but not in state → import step finds UUID and imports → apply shows no changes or only workspace assignment changes ✅
- [ ] Trigger `workload-dbx.yaml` with `destroy=true` → import step is skipped (`if: inputs.destroy != true`) → destroy proceeds normally ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)