### PR TITLE
docs: CI log review for issue #80 — document untested import branch

### DIFF
--- a/docs/sessions/2026-03-06-008-issue-80-ci-log-review.md
+++ b/docs/sessions/2026-03-06-008-issue-80-ci-log-review.md
@@ -1,0 +1,57 @@
+# Session 2026-03-06-008 — Issue #80: CI Log Review After PR #81 Merge
+
+## Runs Reviewed
+
+After PR #81 merged, four workload-dbx workflow runs were executed and reviewed.
+
+| Run ID | Trigger | Branch hit in import step | Apply result |
+|--------|---------|--------------------------|--------------|
+| 22767532932 | push (PR #81 merge) | Branch 2: "No existing metastore found — Terraform will create a fresh one" | Created metastore `6ecb25ac-...` + all resources |
+| 22767625301 | workflow_dispatch (apply) | Branch 1: "Metastore already in Terraform state — skipping import" | 0 added, 0 changed, 0 destroyed |
+| 22767700784 | workflow_dispatch (destroy) | Step skipped (`inputs.destroy != true` = false) | Destroyed: assignment, metastore, credential, location |
+| 22767808987 | workflow_dispatch (apply) | Branch 2: "No existing metastore found — Terraform will create a fresh one" | Created metastore + all resources |
+
+## Tested Scenarios ✅
+
+- **Clean recreate** (metastore deleted, apply creates fresh): confirmed × 2 (runs 22767532932, 22767808987)
+- **Already in state** (idempotent apply): confirmed × 1 (run 22767625301)
+- **Destroy** (import step correctly skipped): confirmed × 1 (run 22767700784)
+
+## Untested Scenario ⚠️
+
+**Branch 3 was never hit**: "Found existing metastore — importing into Terraform state"
+
+This branch handles the failed-destroy recovery case: metastore exists in the Databricks
+account but has been removed from Terraform state. It was never triggered in CI because:
+- Runs 22767532932 and 22767808987 ran after a successful destroy (metastore truly gone)
+- Run 22767625301 ran while metastore was already in state
+
+To trigger branch 3, the state must be manually manipulated:
+
+```bash
+terraform -chdir=infra/workload-dbx init \
+  -backend-config="resource_group_name=rg-tfstate" \
+  -backend-config="storage_account_name=st<UNIQ>tfstate" \
+  -backend-config="container_name=workload-tfstate" \
+  -backend-config="key=dbx.tfstate"
+
+terraform -chdir=infra/workload-dbx state rm databricks_metastore.this
+```
+
+After removing the resource from state, trigger `workload-dbx.yaml` (no destroy).
+Expected output in import step:
+```
+Found existing metastore <uuid> — importing into Terraform state
+databricks_metastore.this: Importing from ID "<uuid>"...
+databricks_metastore.this: Import prepared!
+```
+Tracked in issue #82.
+
+## Notes
+
+- The destroy run (22767700784) confirmed `force_destroy = true` works correctly for
+  a fresh metastore created by the new code — all 4 resources destroyed cleanly.
+- The new metastore UUID after recreate differs from the previous one (as expected for
+  a fresh creation). The `metastore_id` Terraform output displays the new UUID in Apply logs.
+- The `METASTORE_ID` GitHub secret was not referenced by any step in any of these runs —
+  confirming the secret is fully decoupled from the workflow.

--- a/docs/status.md
+++ b/docs/status.md
@@ -12,7 +12,7 @@ opened, closed, or changed severity during the session.
 |-------|----------|-------|-------|
 | [#40](https://github.com/nobhri/azure-dbx-mock-platform/issues/40) | MEDIUM | OIDC not configured for pull_request subject | PR CI always fails Azure login. Fix: add `pull_request` federated credential in Entra ID. No code change needed. |
 | [#53](https://github.com/nobhri/azure-dbx-mock-platform/issues/53) | LOW | Document GRANT CREATE CATALOG prerequisite | Update GETTING_STARTED.md and post-destroy-grants runbook. Partially addressed by `docs/runbooks/post-destroy-grants.md`. |
-| [#80](https://github.com/nobhri/azure-dbx-mock-platform/issues/80) | HIGH | workload-dbx apply fails after successful destroy: static import block uses stale METASTORE_ID | Replace static `import {}` block with dynamic CI discovery step; remove `METASTORE_ID` secret dependency. Fix: PR #81. |
+| [#82](https://github.com/nobhri/azure-dbx-mock-platform/issues/82) | LOW | Test coverage gap: dynamic metastore import path not exercised in CI | Branch 3 ("Found existing metastore — importing") never triggered. Requires manual `terraform state rm` to test. See session-008 for procedure. |
 
 ---
 
@@ -31,6 +31,7 @@ These require direct human action in Azure, GitHub, or Databricks — cannot be 
 
 | Issue | Title | Closed by |
 |-------|-------|-----------|
+| [#80](https://github.com/nobhri/azure-dbx-mock-platform/issues/80) | workload-dbx apply fails after successful destroy: static import block uses stale METASTORE_ID | PR #81 — dynamic metastore discovery step; METASTORE_ID secret removed |
 | [#68](https://github.com/nobhri/azure-dbx-mock-platform/issues/68) | workload-catalog fails when workload-dbx external location not present | PR #78 — preflight check added to workflow; GETTING_STARTED.md updated |
 | [#64](https://github.com/nobhri/azure-dbx-mock-platform/issues/64) | METASTORE_ID secret had wrong UUID (account ID copied instead of metastore ID) | PRs #72 #74 #75 — import block restored; correct UUID set; apply succeeded |
 | [#62](https://github.com/nobhri/azure-dbx-mock-platform/issues/62) | Metastore state drift (reached region limit) | PR #63 — import block added |


### PR DESCRIPTION
## Summary

- `docs/sessions/2026-03-06-008-issue-80-ci-log-review.md`: new session note with full CI run table, tested scenarios, untested scenario, and manual test procedure
- `docs/status.md`: close issue #80 (moved to Recently Closed); add issue #82 to Open Issues

## CI Runs Reviewed

| Run ID | Branch hit | Result |
|--------|-----------|--------|
| 22767532932 | Branch 2: no metastore → create fresh | ✅ Apply succeeded |
| 22767625301 | Branch 1: already in state → skip | ✅ 0 changes |
| 22767700784 | Import step skipped (destroy) | ✅ Destroy complete |
| 22767808987 | Branch 2: no metastore → create fresh | ✅ Apply succeeded |

## Gap

Branch 3 ("Found existing metastore — importing") was never triggered. It requires the metastore to exist in the Databricks account while absent from Terraform state — a condition that can only be created by manual `terraform state rm`. Issue #82 tracks this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)