### PR TITLE
docs: update ADR-005 — Metastore-scoped grants to Platform Layer (closes #87)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The design intentionally reflects a common scenario: **a low-to-mid maturity org
 │                                                              │
 │  EntraID Groups ──sync──→ Databricks                         │
 │  Permissions assigned to Groups only — never to individuals  │
-│  Group → Workspace/Catalog assignment: Terraform             │
+│  Group → Workspace/Catalog assignment: Platform Layer (SQL)  │
 └──────────────────────────────────────────────────────────────┘
 ```
 
@@ -61,9 +61,9 @@ The design intentionally reflects a common scenario: **a low-to-mid maturity org
 │  Terraform — one-time setup only                     │
 │  (Metastore creation, Storage credential binding)    │
 ├──────────────────────────────────────────────────────┤
-│  Catalog / Schema Layer                              │
+│  Catalog / Schema / Permission Layer                 │
 │  Jinja2 + Python Notebook — Data Platform team       │
-│  (Environment-parametrized SQL, run via CI/CD)       │
+│  (DDL + GRANT, config-driven, run via CI/CD)         │
 ├──────────────────────────────────────────────────────┤
 │  Job / Workflow Layer                                │
 │  Asset Bundles — Data Engineering team               │
@@ -189,9 +189,11 @@ See [ADR-004](docs/adr/004-consumer-access.md) for full rationale.
 
 ### ADR-005: Identity & Permission Model — Group-Based Access via EntraID Sync
 
-Permissions are assigned to EntraID Groups only — never to individual users — with all Workspace
-and Catalog grants managed via Terraform. Group-based assignment ensures access is managed through a
-single source of truth (EntraID) and offboarding propagates automatically. EntraID Native Sync is
+Permissions are assigned to Groups only — never to individual users. All Metastore-scoped grants
+(Workspace, Catalog, Schema) are managed via Jinja2 + SQL Notebook in the Platform Layer.
+Group-based assignment ensures access is managed through a single source of truth and offboarding
+propagates automatically. In production, groups are sourced from EntraID via Native Sync; in this
+mock environment, Databricks-native groups are used as a simplification. EntraID Native Sync is
 preferred over SCIM for its support of nested groups and lower setup complexity.
 
 See [ADR-005](docs/adr/005-group-permissions.md) for full rationale.

--- a/docs/adr/005-group-permissions.md
+++ b/docs/adr/005-group-permissions.md
@@ -1,6 +1,6 @@
 # ADR-005: Identity & Permission Model — Group-Based Access via EntraID Sync
 
-**Status:** Accepted
+**Status:** Accepted (updated 2026-03-07)
 **Date:** 2026-02-01
 
 ---
@@ -15,11 +15,27 @@ structured so that it remains auditable and manageable as the team scales?
 
 ## Decision
 
-Permissions are assigned to **EntraID Groups only — never to individual users or service principals
-(except the platform SP itself)**. All Workspace and Catalog permission grants are managed via
-Terraform. No `GRANT` to individual user principals appears anywhere in the platform automation.
+Permissions are assigned to **Groups only — never to individual users or service principals
+(except the platform SP itself)**. No `GRANT` to individual user principals appears anywhere in
+the platform automation.
 
-EntraID Groups are synced into Databricks via **Native Sync** (not SCIM provisioning).
+**Responsibility boundary:** Everything under Metastore Admin jurisdiction is managed by the
+Platform Layer (SQL/Jinja2), not Terraform:
+
+- Workspace permission grants (who can enter the Workspace)
+- Catalog and Schema permission grants
+- Group management within Databricks
+
+Terraform's responsibility ends at infrastructure creation:
+
+- Azure resources, Databricks Workspace creation, Metastore creation
+- Workspace-to-Metastore binding
+
+Terraform does not touch any grants or permissions for Metastore-scoped resources.
+
+In production environments, EntraID Groups are synced into Databricks via **Native Sync**
+(not SCIM provisioning). In this mock environment, Databricks-native groups are used as a
+simplification (see [Trade-offs Accepted](#trade-offs-accepted)).
 
 ---
 
@@ -38,39 +54,188 @@ Individual permission grants fail at scale for three reasons:
    updating every resource. Adding them to the correct EntraID group grants all necessary access
    in a single operation.
 
+**Why Platform Layer (SQL) instead of Terraform for grants?**
+
+Catalog, Schema, and their GRANTs share the same lifecycle: they are created, modified, and
+retired together by the Data Platform team. Placing GRANTs in Terraform while the objects they
+govern are managed in SQL would split responsibility for the same resource across two tools and
+two teams, breaking the principle that Terraform owns infrastructure and the Platform Layer owns
+Metastore-scoped governance.
+
 ---
 
 ## Trade-offs Accepted
 
 - Group management is now a prerequisite: before a new team member can access any Databricks
-  resource, the correct EntraID group must exist and be assigned. This is additional setup friction
+  resource, the correct group must exist and be assigned. This is additional setup friction
   for the first deployment.
 - Native Sync has a propagation delay: group membership changes in EntraID take some minutes to
   appear in Databricks. This is acceptable for access management (not a real-time requirement).
 - Service principal grants (e.g., the CI/CD SP) are an exception to the group-only rule — the SP
   is granted directly as it is not a human user and has no EntraID group membership.
 
+**Mock Implementation Simplification:**
+
+In this mock environment, EntraID Sync is omitted and Databricks-native groups are used instead.
+Demonstrating IdP sync in a single-developer repository adds setup complexity without validating
+the group-based access principle itself — native groups are still groups. In production,
+EntraID Native Sync must be used (this ADR's recommendation is unchanged).
+
+**Membership Separation:**
+
+Group structure (what groups exist) and permissions (GRANT statements) are declared in the
+repository and managed via CI/CD. Group membership (who belongs to each group) is managed outside
+the repository:
+
+- **Mock:** Databricks CLI or Account Console GUI
+- **Production:** EntraID (user assignment to EntraID groups; Native Sync propagates to Databricks)
+
+Email addresses and individual user identifiers are not committed to this repository (public repo).
+This separation is consistent with the principle that membership is an IdP concern, not a
+platform-layer concern.
+
 ---
 
 ## Why Native Sync Over SCIM?
 
-| Dimension              | Native Sync                   | SCIM Provisioning            |
-|------------------------|-------------------------------|------------------------------|
-| Nested group support   | Yes                           | Limited                      |
-| Setup complexity       | Lower (no external SCIM app)  | Higher (requires SCIM config)|
-| Sync trigger           | Near-real-time (token issue)  | Configurable polling         |
-| Group creation in DBX  | Automatic                     | Requires SCIM PUT            |
+| Dimension              | Native Sync                   | SCIM Provisioning             |
+|------------------------|-------------------------------|-------------------------------|
+| Nested group support   | Yes                           | Limited                       |
+| Setup complexity       | Lower (no external SCIM app)  | Higher (requires SCIM config) |
+| Sync trigger           | Near-real-time (token issue)  | Configurable polling          |
+| Group creation in DBX  | Automatic                     | Requires SCIM PUT             |
 
 Native Sync is preferred because it supports nested groups (which SCIM provisioning handles
 inconsistently across IdP versions) and requires no external SCIM application configuration.
 
 ---
 
+## Group Design
+
+Three groups cover the full access topology (management / production / consumption):
+
+### `data_platform_admins`
+
+Full access across all environments. Responsible for platform operations.
+
+- **Typical roles:** Data Platform team, IT Infrastructure team members who operate the data
+  platform
+- **Responsibilities:** Catalog/Schema creation, GRANT management, audit, troubleshooting
+- **Note:** In smaller organizations, Data Engineers may hold this role as well
+
+### `data_engineers`
+
+- **dev/qa:** READ + WRITE — interactive development and validation
+- **prod:** READ only — writes to prod are CI/CD Job-only; no direct human writes
+- **Typical roles:** Data Engineering team, Analytics Engineering team
+- **Responsibilities:** ETL pipeline development, data modeling, table/view creation
+- **Design intent:** Separating prod write access from dev/qa write access enforces CI/CD
+  discipline without blocking developer iteration
+
+### `data_consumers`
+
+READ access to the gold/analytics layer only.
+
+- **Typical roles:** BI/reporting teams, business units (sales, manufacturing, HR, finance, etc.),
+  leadership
+- **Responsibilities:** Dashboard creation, ad-hoc analysis on curated datasets
+- **Note:** Depending on organizational policy, consumers may be granted access to SQL Warehouses
+  only — not to interactive clusters
+
+### Grant Granularity
+
+GRANTs are defined at **Schema level**, not Catalog level. Reason: within a single Catalog,
+schemas may carry data of different sensitivity and purpose (e.g., `bronze` vs `gold`).
+Catalog-level grants would over-provision access.
+
+---
+
+## Environment-Specific GRANT (Production Consideration)
+
+In this mock environment, a single Catalog (`mock`) is used and GRANTs are not differentiated by
+environment (see [Mock Environment Simplification](#mock-environment-simplification)).
+
+In production, environments should be separated by Catalog or Workspace, and GRANTs should
+reflect that separation:
+
+- **prod:** `data_engineers` receive READ only. Writes are performed exclusively by CI/CD Jobs
+  (Service Principal). No direct human writes to prod.
+- **dev/qa:** `data_engineers` receive READ + WRITE to support interactive development.
+
+This aligns with the CI/CD execution policy: prod deployments are merge-to-main only; dev/qa
+allow workflow_dispatch.
+
+---
+
+## Mock Environment Simplification
+
+- **Single Catalog:** `mock` only. No environment-specific Catalog separation (e.g., `mock_dev`,
+  `mock_staging`, `mock_prod`).
+- **No environment-differentiated GRANTs:** All groups receive the same grants regardless of
+  environment. In production, `data_engineers` would not have WRITE access to prod.
+- **Native groups instead of EntraID Sync:** As described above.
+
+This simplification reflects a deliberate scope decision: the mock environment demonstrates
+architectural patterns and design decisions — not the full operational complexity of a
+multi-environment enterprise deployment. The target architecture is documented in this ADR and
+the README.
+
+---
+
 ## Consequences
 
-- Adding a new workspace requires only adding a parameter to Terraform (group-to-workspace
-  assignment) — no new individual grant statements.
-- Access control reviews (SOC 2, audit, etc.) can be answered by inspecting EntraID group
-  membership and Terraform-managed grants — two sources of truth, both auditable.
-- The platform team must maintain an EntraID group structure that maps to the desired access
-  topology before standing up new workspaces.
+- Adding a new workspace requires two steps: (1) create the Workspace in Terraform (infrastructure
+  layer); (2) add the corresponding Workspace assignment grants in the Platform Layer (SQL/Jinja2).
+  No new individual grant statements are needed in either step.
+- Access control reviews (SOC 2, audit, etc.) are answered from three sources:
+  - **What should be (declared intent):** GRANT definitions in the repository (YAML/SQL templates)
+  - **What happened (execution evidence):** Databricks system tables (`system.access.audit` and
+    related tables) — built-in audit logging that automatically records all GRANT operations
+  - **Who is who (identity source):** EntraID group membership (prod) / Databricks-native
+    groups (mock)
+  - Terraform state is **not** an audit source for grants — grants are no longer Terraform-managed.
+- The platform team must maintain a group structure that maps to the desired access topology before
+  standing up new workspaces. Group structure changes are CI/CD-driven; membership changes are
+  IdP-driven (or CLI-driven in mock).
+- Using built-in Databricks system tables as the audit log eliminates the need for a custom audit
+  log implementation.
+
+---
+
+## Production Consideration: Catalog/Schema Decommissioning
+
+**Mock environment:** Metastore has `force_destroy = true` (PR [#50](https://github.com/nobhri/azure-dbx-mock-platform/pull/50)).
+A successful `terraform destroy` cascade-deletes the Metastore and all managed Catalogs.
+Individual Catalog/Schema deletion is not required.
+
+**Production decommissioning options:**
+
+| Approach | Description | Risk | Recommended for |
+|----------|-------------|------|-----------------|
+| DROP CASCADE | `DROP SCHEMA ... CASCADE` — deletes schema and all contents | Unrecoverable if run against prod accidentally | dev/staging only |
+| Soft delete (recommended) | REVOKE all grants + add COMMENT marking schema as deprecated; manual DROP after review period | Data remains; reversible; audit trail in system tables | prod |
+| Terraform-managed delete | CREATE in SQL, DELETE in Terraform — asymmetric ownership | Breaks responsibility boundary | Not recommended |
+
+**Recommended procedure (prod):**
+
+```sql
+-- Step 1: Revoke access from all groups
+REVOKE ALL PRIVILEGES ON SCHEMA `catalog`.`schema` FROM `data_platform_admins`;
+REVOKE ALL PRIVILEGES ON SCHEMA `catalog`.`schema` FROM `data_engineers`;
+REVOKE ALL PRIVILEGES ON SCHEMA `catalog`.`schema` FROM `data_consumers`;
+
+-- Step 2: Mark as deprecated
+COMMENT ON SCHEMA `catalog`.`schema` IS 'DEPRECATED yyyy-mm-dd -- do not use';
+
+-- Step 3: Verify no active usage (query system.access.audit for recent SELECT history)
+-- Step 4: After review period (e.g., 30 days), execute manually with approval:
+DROP SCHEMA `catalog`.`schema` CASCADE;
+```
+
+**Design rationale:**
+
+- Automated DROP CASCADE in CI/CD pipelines is too high-risk for production data
+- Soft delete allows recovery if unexpected dependencies are found during the review period
+- REVOKE operations fit naturally into the existing GRANT pipeline as its inverse
+- Databricks system tables automatically record when access was revoked — no custom logging needed
+- The review period surfaces dependencies that were not captured in documentation

--- a/docs/sessions/2026-03-07-002-adr-005-grant-platform-layer.md
+++ b/docs/sessions/2026-03-07-002-adr-005-grant-platform-layer.md
@@ -1,0 +1,43 @@
+# Session 2026-03-07-002 — ADR-005: Grant Responsibility Moved to Platform Layer
+
+## Objective
+
+Update ADR-005 (Identity & Permission Model) to reflect the confirmed design decision that all
+Metastore-scoped grants are managed by the Platform Layer (SQL/Jinja2), not Terraform. Update
+README accordingly.
+
+## Changes Made
+
+### `docs/adr/005-group-permissions.md` — full rewrite
+
+- **Decision section:** Added explicit responsibility boundary — Terraform ends at infrastructure
+  creation; all Metastore-scoped grants (Workspace, Catalog, Schema) belong to Platform Layer.
+  Added rationale for why grants follow the SQL layer (same lifecycle as the objects they govern).
+- **Trade-offs Accepted:** Added Mock Implementation Simplification (native groups vs EntraID Sync)
+  and Membership Separation (what's in the repo vs what's managed externally).
+- **Group Design:** New section documenting the 3-group structure (`data_platform_admins`,
+  `data_engineers`, `data_consumers`) with typical roles, responsibilities, and grant granularity
+  (Schema level, not Catalog level).
+- **Environment-Specific GRANT:** New section documenting prod vs dev/qa GRANT differences
+  (prod: data_engineers READ only; dev/qa: READ + WRITE).
+- **Mock Environment Simplification:** New section documenting single Catalog, no env-differentiated
+  GRANTs, and native groups.
+- **Consequences:** Updated to reflect new audit sources (system tables + repo YAML, not Terraform
+  state). Updated workspace addition to be a two-step process.
+- **Catalog/Schema Decommissioning:** New section with prod decommissioning options table and
+  recommended soft-delete procedure.
+
+### `README.md` — three patches
+
+1. Architecture Overview figure: `Terraform` → `Platform Layer (SQL)` for group assignment line
+2. Layer Separation figure: `Catalog / Schema Layer` → `Catalog / Schema / Permission Layer`
+3. ADR-005 summary: updated to reflect Platform Layer grants and Mock simplification
+
+## Issues Addressed
+
+- Closes #87 — ADR conflict (ADR-001 assigns catalog to Jinja2; ADR-005 previously assigned grants
+  to Terraform). Resolution: Option A — amend ADR-005, move grants to Platform Layer.
+
+## Branch
+
+`docs/adr-005-grant-platform-layer`

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,6 +1,6 @@
 # Project Status Snapshot
 
-**Last updated:** 2026-03-06
+**Last updated:** 2026-03-07
 **Update instructions:** Edit this file at the end of each docs PR. Update any issue that was
 opened, closed, or changed severity during the session.
 
@@ -13,8 +13,7 @@ opened, closed, or changed severity during the session.
 | [#40](https://github.com/nobhri/azure-dbx-mock-platform/issues/40) | MEDIUM | OIDC not configured for pull_request subject | PR CI always fails Azure login. Fix: add `pull_request` federated credential in Entra ID. No code change needed. |
 | [#53](https://github.com/nobhri/azure-dbx-mock-platform/issues/53) | LOW | Document GRANT CREATE CATALOG prerequisite | Update GETTING_STARTED.md and post-destroy-grants runbook. Partially addressed by `docs/runbooks/post-destroy-grants.md`. |
 | [#84](https://github.com/nobhri/azure-dbx-mock-platform/issues/84) | HIGH | Preflight fix commit not merged into main — old buggy code still active | Fix pushed after PR #79 merged; dangling commit. PR #84 re-applies the fix. |
-| [#87](https://github.com/nobhri/azure-dbx-mock-platform/issues/87) | MEDIUM | ADR conflict: catalog grants not assignable to Terraform when catalog is Jinja2-managed | ADR-001 assigns catalog to Jinja2; ADR-005 assigns all grants to Terraform. Options: A (amend ADR-005, grants in Jinja2), B (amend ADR-001, grants in Terraform with ordering dep), C (new ADR-006). Needs decision. |
-| [#85](https://github.com/nobhri/azure-dbx-mock-platform/issues/85) | MEDIUM | UC catalog/schema not visible to human user — missing USE CATALOG/USE SCHEMA grants | Per ADR-005: Entra ID group via Native Sync. Runbook updated. Pending: create Entra ID group + run grants. Blocked by #87. |
+| [#85](https://github.com/nobhri/azure-dbx-mock-platform/issues/85) | MEDIUM | UC catalog/schema not visible to human user — missing USE CATALOG/USE SCHEMA grants | Per ADR-005 (updated): grants in Platform Layer (SQL). Runbook updated. Pending: create Databricks-native group + run grants. No longer blocked. |
 | [#82](https://github.com/nobhri/azure-dbx-mock-platform/issues/82) | LOW | Test coverage gap: dynamic metastore import path not exercised in CI | Branch 3 ("Found existing metastore — importing") never triggered. Requires manual `terraform state rm` to test. See session-008 for procedure. |
 
 ---
@@ -36,6 +35,7 @@ These require direct human action in Azure, GitHub, or Databricks — cannot be 
 
 | Issue | Title | Closed by |
 |-------|-------|-----------|
+| [#87](https://github.com/nobhri/azure-dbx-mock-platform/issues/87) | ADR conflict: catalog grants not assignable to Terraform when catalog is Jinja2-managed | ADR-005 updated — Option A: all Metastore-scoped grants moved to Platform Layer (SQL/Jinja2) |
 | [#80](https://github.com/nobhri/azure-dbx-mock-platform/issues/80) | workload-dbx apply fails after successful destroy: static import block uses stale METASTORE_ID | PR #81 — dynamic metastore discovery step; METASTORE_ID secret removed |
 | [#68](https://github.com/nobhri/azure-dbx-mock-platform/issues/68) | workload-catalog fails when workload-dbx external location not present | PR #78 — preflight check added to workflow; GETTING_STARTED.md updated |
 | [#64](https://github.com/nobhri/azure-dbx-mock-platform/issues/64) | METASTORE_ID secret had wrong UUID (account ID copied instead of metastore ID) | PRs #72 #74 #75 — import block restored; correct UUID set; apply succeeded |


### PR DESCRIPTION
## Summary

- Resolves ADR conflict (#87): ADR-001 assigns Catalog/Schema to Jinja2; ADR-005 previously claimed Terraform owned all grants
- Decision: **Option A** — all Metastore-scoped grants (Workspace, Catalog, Schema) are managed by the Platform Layer (SQL/Jinja2)
- ADR-005 is updated (not deprecated); core principles (group-only, Native Sync preference) are preserved

## Changes

**`docs/adr/005-group-permissions.md`** — significant expansion:
- Decision section: explicit Terraform vs Platform Layer responsibility boundary + rationale for why grants follow the SQL layer
- Trade-offs Accepted: Mock simplification (native groups) + Membership Separation
- Group Design: 3-group topology (`data_platform_admins`, `data_engineers`, `data_consumers`) with typical roles and grant granularity (Schema level)
- Environment-Specific GRANT: prod vs dev/qa differences
- Mock Environment Simplification: single Catalog, no env-differentiated GRANTs, native groups
- Consequences: updated audit sources (system tables + repo YAML; Terraform state removed); workspace addition is now a two-step process
- Catalog/Schema Decommissioning: new section with prod soft-delete procedure

**`README.md`** — three patches:
1. Architecture Overview: `Terraform` → `Platform Layer (SQL)` for group assignment line
2. Layer Separation: `Catalog / Schema Layer` → `Catalog / Schema / Permission Layer`
3. ADR-005 summary: reflects Platform Layer grants and Mock simplification

**`docs/status.md`** — issue #87 moved to Recently Closed; #85 unblocked

## Closes

- Closes #87 (ADR conflict resolved — Option A chosen)

## Test plan

- [ ] Review ADR-005 for internal consistency (responsibility boundary, rationale, trade-offs, group design, consequences all align)
- [ ] Review README figures — both code blocks render correctly
- [ ] README ADR-005 summary accurately reflects the updated ADR
- [ ] Verify #85 (human user visibility) is now unblocked (grants belong to Platform Layer; no Terraform dep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)