### PR TITLE
docs: make git worktree usage mandatory

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,9 @@ Azure, Terraform, Databricks, Asset Bundles, Unity Catalog, Jinja2, GitHub Actio
 - Always create a new branch before making any changes
 - Never commit directly to main
 - Always create PR to main, never push to main directly
-- Use git worktrees (`.claude/worktrees/<branch-name>`) for parallel sessions (e.g. tmux with multiple Claude Code terminals)
+- Always work inside a git worktree, never in the main working tree
+- At session start, create a worktree before touching any files:
+    `git worktree add .claude/worktrees/<branch-name> -b <branch-name>`
 - Each worktree gets its own branch; all worktrees target main via PR
 
 ## Autonomy Level
@@ -45,6 +47,7 @@ Azure, Terraform, Databricks, Asset Bundles, Unity Catalog, Jinja2, GitHub Actio
 - Prod execution: CI/CD only, no manual runs
 
 ## Session Lifecycle
+- At session start: create worktree (see Git section) before editing any files
 - At session start: read `docs/status.md` before running any `gh` commands
 - At session end: update `docs/status.md` if any issues were opened, closed, or changed severity
 


### PR DESCRIPTION
## Summary
- Replaces the optional "for parallel sessions" framing with a hard rule: always work inside a worktree, never in the main working tree
- Adds the exact `git worktree add` command so every session has a concrete action to follow
- Inserts worktree creation as the first step in Session Lifecycle, before reading `docs/status.md`

## Test plan
- [ ] Verify CLAUDE.md renders correctly on GitHub
- [ ] Confirm Session Lifecycle section ordering is logical (worktree → status.md → end-of-session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)