### PR TITLE
fix: add PyYAML library to setup_platform job cluster (closes #91)

### DIFF
--- a/platform/databricks.yml
+++ b/platform/databricks.yml
@@ -27,6 +27,9 @@ resources:
             base_parameters:
               storage_account_name: "${var.storage_account_name}"
               uc_root_container: "${var.uc_root_container}"
+          libraries:
+            - pypi:
+                package: PyYAML
           new_cluster:
             spark_version: "14.3.x-scala2.12"
             node_type_id: "Standard_DS3_v2"


### PR DESCRIPTION
## Problem

`workload-catalog` fails with:
```
ModuleNotFoundError: No module named 'yaml'
```

DBR 14.3.x (non-ML) does not include PyYAML. `setup_platform.py` imports `yaml` to load the YAML configs, but the job cluster had no library spec.

## Fix

Add `PyYAML` as a PyPI library in `platform/databricks.yml` — Databricks installs it on the cluster before the notebook runs.

```yaml
libraries:
  - pypi:
      package: PyYAML
```

`jinja2` is pre-installed on DBR 14.3.x and does not need to be added.

## Test plan

- [ ] `workload-catalog` CI run on main succeeds after merge
- [ ] `bundle run setup_platform` completes without `ModuleNotFoundError`

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)