### PR TITLE
fix: replace CREATE GROUP SQL with SDK group creation (closes #93)

### DIFF
--- a/platform/notebooks/setup_platform.py
+++ b/platform/notebooks/setup_platform.py
@@ -113,10 +113,22 @@ render_and_execute("create_schema.sql.j2", {
 
 # COMMAND ----------
 
-# Step 3: CREATE GROUPS
-render_and_execute("create_groups.sql.j2", {
-    "groups": groups_config["groups"],
-})
+# Step 3: CREATE GROUPS via Databricks SDK
+# CREATE GROUP is not a SQL statement -- groups are managed via the REST API.
+# databricks-sdk is pre-installed on DBR 14.3.x.
+# Idempotent: existing groups are skipped.
+from databricks.sdk import WorkspaceClient
+
+w = WorkspaceClient()
+existing_group_names = {g.display_name for g in w.groups.list()}
+
+for group in groups_config["groups"]:
+    name = group["name"]
+    if name in existing_group_names:
+        print(f"Group already exists (skip): {name}")
+    else:
+        w.groups.create(display_name=name)
+        print(f"Created group: {name}")
 
 # COMMAND ----------
 

--- a/platform/templates/create_groups.sql.j2
+++ b/platform/templates/create_groups.sql.j2
@@ -1,6 +1,0 @@
--- ADR-005: Group-based access control -- groups only, never individual users
--- ADR-003: Idempotent by construction
-
-{% for group in groups %}
-CREATE GROUP IF NOT EXISTS `{{ group.name }}`;
-{% endfor %}


### PR DESCRIPTION
## Problem

`workload-catalog` fails with:
```
[PARSE_SYNTAX_ERROR] Syntax error at or near 'GROUP'. SQLSTATE: 42601
CREATE GROUP IF NOT EXISTS `data_platform_admins`
```

`CREATE GROUP` is not a Unity Catalog SQL statement. Databricks groups are managed via REST API — `spark.sql()` cannot execute this.

## Fix

**Removed:** `platform/templates/create_groups.sql.j2` (invalid SQL template)

**Replaced** Step 3 in `setup_platform.py` — group creation now uses `databricks-sdk` `WorkspaceClient.groups` API, which is pre-installed on DBR 14.3.x:

```python
from databricks.sdk import WorkspaceClient

w = WorkspaceClient()
existing_group_names = {g.display_name for g in w.groups.list()}

for group in groups_config["groups"]:
    name = group["name"]
    if name in existing_group_names:
        print(f"Group already exists (skip): {name}")
    else:
        w.groups.create(display_name=name)
        print(f"Created group: {name}")
```

Idempotent: lists existing groups first, skips any that already exist.

## Test plan

- [ ] `workload-catalog` CI run on main succeeds after merge
- [ ] Groups `data_platform_admins`, `data_engineers`, `data_consumers` exist in Databricks workspace after run
- [ ] Re-run is safe — existing groups are skipped without error

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)