### PR TITLE
fix: pass host+token explicitly to WorkspaceClient in notebook context

### DIFF
--- a/platform/notebooks/setup_platform.py
+++ b/platform/notebooks/setup_platform.py
@@ -116,10 +116,16 @@ render_and_execute("create_schema.sql.j2", {
 # Step 3: CREATE GROUPS via Databricks SDK
 # CREATE GROUP is not a SQL statement -- groups are managed via the REST API.
 # databricks-sdk is pre-installed on DBR 14.3.x.
+# WorkspaceClient() auto-auth does not work on job clusters; pass host+token
+# explicitly from the notebook context (standard pattern for notebook clusters).
 # Idempotent: existing groups are skipped.
 from databricks.sdk import WorkspaceClient
 
-w = WorkspaceClient()
+_ctx = dbutils.notebook.entry_point.getDbutils().notebook().getContext()
+w = WorkspaceClient(
+    host=_ctx.apiUrl().get(),
+    token=_ctx.apiToken().get(),
+)
 existing_group_names = {g.display_name for g in w.groups.list()}
 
 for group in groups_config["groups"]:


### PR DESCRIPTION
## Problem

`workload-catalog` fails at Step 3 (CREATE GROUPS) with:

```
ValueError: default auth: cannot configure default credentials
```

`WorkspaceClient()` with no arguments tries to auto-discover credentials via environment variables, config files, or Azure managed identity. None of these are available on a Databricks job cluster running under a personal access token issued to the CI SP.

## Root cause

Auto-auth in `databricks-sdk` does not work inside Databricks job clusters when credentials aren't set via env vars or config file. The cluster's own token is accessible only through the notebook context (`dbutils`), not through the SDK's default credential chain.

## Fix

Read `host` and `token` from the notebook context and pass them explicitly to `WorkspaceClient`:

```python
_ctx = dbutils.notebook.entry_point.getDbutils().notebook().getContext()
w = WorkspaceClient(
    host=_ctx.apiUrl().get(),
    token=_ctx.apiToken().get(),
)
```

This is the documented pattern for using `databricks-sdk` inside a Databricks notebook or job cluster.

## Test plan

- [ ] `workload-catalog` CI run on main succeeds after merge
- [ ] Step 3 (CREATE GROUPS) completes without `ValueError`
- [ ] Groups `data_platform_admins`, `data_engineers`, `data_consumers` created in workspace

🤖 Generated with [Claude Code](https://claude.com/claude-code)