### PR TITLE
fix: replace SDK groups.create with SCIM REST API via requests

### DIFF
--- a/platform/notebooks/setup_platform.py
+++ b/platform/notebooks/setup_platform.py
@@ -113,27 +113,37 @@ render_and_execute("create_schema.sql.j2", {
 
 # COMMAND ----------
 
-# Step 3: CREATE GROUPS via Databricks SDK
+# Step 3: CREATE GROUPS via SCIM REST API
 # CREATE GROUP is not a SQL statement -- groups are managed via the REST API.
-# databricks-sdk is pre-installed on DBR 14.3.x.
-# WorkspaceClient() auto-auth does not work on job clusters; pass host+token
-# explicitly from the notebook context (standard pattern for notebook clusters).
-# Idempotent: existing groups are skipped.
-from databricks.sdk import WorkspaceClient
+# Using requests (pre-installed on all DBR versions) instead of databricks-sdk
+# to avoid SDK version incompatibilities across DBR releases.
+# Idempotent: list existing groups first, skip any that already exist.
+import requests
 
 _ctx = dbutils.notebook.entry_point.getDbutils().notebook().getContext()
-w = WorkspaceClient(
-    host=_ctx.apiUrl().get(),
-    token=_ctx.apiToken().get(),
-)
-existing_group_names = {g.display_name for g in w.groups.list()}
+_host = _ctx.apiUrl().get()
+_token = _ctx.apiToken().get()
+_headers = {"Authorization": f"Bearer {_token}", "Content-Type": "application/json"}
+_scim_base = f"{_host}/api/2.0/preview/scim/v2/Groups"
+
+_resp = requests.get(_scim_base, headers=_headers)
+_resp.raise_for_status()
+existing_group_names = {g["displayName"] for g in _resp.json().get("Resources", [])}
 
 for group in groups_config["groups"]:
     name = group["name"]
     if name in existing_group_names:
         print(f"Group already exists (skip): {name}")
     else:
-        w.groups.create(display_name=name)
+        _r = requests.post(
+            _scim_base,
+            headers=_headers,
+            json={
+                "schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group"],
+                "displayName": name,
+            },
+        )
+        _r.raise_for_status()
         print(f"Created group: {name}")
 
 # COMMAND ----------


### PR DESCRIPTION
## Problem

`workload-catalog` fails at Step 3 (CREATE GROUPS) with:

```
TypeError: GroupsAPI.create() missing 1 required positional argument: 'id'
```

The `GroupsAPI.create()` method signature in the `databricks-sdk` version bundled with DBR 14.3.x differs from the current SDK docs. The method requires a positional `id` argument that makes no sense for a create operation — this is a version-specific API incompatibility.

## Fix

Replace SDK call with direct SCIM REST API call via `requests` (pre-installed on all DBR versions):

```python
import requests

_ctx = dbutils.notebook.entry_point.getDbutils().notebook().getContext()
_host = _ctx.apiUrl().get()
_token = _ctx.apiToken().get()
_headers = {"Authorization": f"Bearer {_token}", "Content-Type": "application/json"}
_scim_base = f"{_host}/api/2.0/preview/scim/v2/Groups"

# List existing groups (idempotency)
_resp = requests.get(_scim_base, headers=_headers)
_resp.raise_for_status()
existing_group_names = {g["displayName"] for g in _resp.json().get("Resources", [])}

for group in groups_config["groups"]:
    name = group["name"]
    if name in existing_group_names:
        print(f"Group already exists (skip): {name}")
    else:
        _r = requests.post(
            _scim_base,
            headers=_headers,
            json={"schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group"], "displayName": name},
        )
        _r.raise_for_status()
        print(f"Created group: {name}")
```

`requests` is stable across all DBR versions. The SCIM v2 Groups API is the underlying API the SDK wraps — going directly eliminates the version dependency.

## Test plan

- [ ] `workload-catalog` CI run on main succeeds after merge
- [ ] Step 3 (CREATE GROUPS) completes without `TypeError`
- [ ] Groups `data_platform_admins`, `data_engineers`, `data_consumers` created in workspace
- [ ] Re-run skips existing groups without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)