### PR TITLE
fix: make GRANT resilient to missing account-level groups; update runbook

### DIFF
--- a/docs/runbooks/post-destroy-grants.md
+++ b/docs/runbooks/post-destroy-grants.md
@@ -36,29 +36,40 @@ GRANT CREATE CATALOG ON METASTORE TO '<SP_client_id>';
 
 Replace `<SP_client_id>` with the value of the `AZURE_CLIENT_ID` GitHub repository secret.
 
-### Step 2 — Catalog visibility grants (run after workload-catalog)
+### Step 2 — Create account-level groups (one-time, before or after workload-catalog)
 
-Per ADR-005, permissions are granted to **Entra ID groups via Native Sync** — not to individual
-users or Databricks-only groups. When a user logs in with their Microsoft account, Entra ID group
-memberships are automatically reflected in Databricks (no SCIM provisioner required).
+Unity Catalog `GRANT` statements target **account-level groups only** — workspace-local groups
+(created via the workspace SCIM API) are not visible to UC. Groups must exist at the Databricks
+account level before GRANTs can be applied.
 
-**Prerequisite:** Create an Entra ID group (e.g., `databricks-platform-users`) and add all
-human users who need catalog access. The group name used in the grant must match exactly.
+In this mock environment, Databricks-native groups are used (ADR-005: Mock Environment
+Simplification). Create the three groups via **Account Console** or **Databricks CLI with an
+account-level profile**:
 
-```sql
--- Allow the Entra ID group to see and use the catalog
-GRANT USE CATALOG ON CATALOG <catalog_name> TO `databricks-platform-users`;
+**Account Console:**
+Databricks Account Console → User Management → Groups → Add Group
 
--- Allow the group to see and use all schemas in the catalog
-GRANT USE SCHEMA ON ALL SCHEMAS IN CATALOG <catalog_name> TO `databricks-platform-users`;
+Groups to create:
+- `data_platform_admins`
+- `data_engineers`
+- `data_consumers`
+
+**Databricks CLI (account-level profile required):**
+```bash
+databricks groups create --display-name data_platform_admins --profile <account-profile>
+databricks groups create --display-name data_engineers --profile <account-profile>
+databricks groups create --display-name data_consumers --profile <account-profile>
 ```
 
-Replace `<catalog_name>` with the catalog name defined in your platform (e.g., `mock_dev`).
+> **Note:** The `workload-catalog` job (Step 4) attempts all GRANTs and emits a `WARNING` for
+> any group that does not exist yet — it does **not** fail. Re-run `workload-catalog` after
+> creating the groups to apply the deferred grants (all GRANT statements are idempotent).
 
-> **Note:** These grants are on the catalog object. If the catalog is dropped and recreated
-> (e.g., after `workload-catalog` runs on a fresh environment), the grants must be re-run.
-> The catalog uses `CREATE CATALOG IF NOT EXISTS` — if the catalog already exists, it is not
-> dropped, and existing grants are preserved.
+**Add yourself to `data_platform_admins`** so you can see the catalog in the Databricks UI:
+```bash
+databricks groups add-member --group-name data_platform_admins --user-name <your-email> \
+  --profile <account-profile>
+```
 
 ---
 
@@ -67,8 +78,8 @@ Replace `<catalog_name>` with the catalog name defined in your platform (e.g., `
 1. `workload-azure` apply ✅
 2. `workload-dbx` apply ✅
 3. **Step 1 grants (SP)** — run before workload-catalog
-4. `workload-catalog` apply ✅
-5. **Step 2 grants (Entra ID group)** — run after workload-catalog
+4. **Step 2 groups (account-level)** — create before or after workload-catalog; re-run catalog job after creation
+5. `workload-catalog` apply ✅ (GRANTs for missing groups emit WARNING, not error; re-run to apply)
 
 ---
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,7 +13,7 @@ opened, closed, or changed severity during the session.
 | [#40](https://github.com/nobhri/azure-dbx-mock-platform/issues/40) | MEDIUM | OIDC not configured for pull_request subject | PR CI always fails Azure login. Fix: add `pull_request` federated credential in Entra ID. No code change needed. |
 | [#53](https://github.com/nobhri/azure-dbx-mock-platform/issues/53) | LOW | Document GRANT CREATE CATALOG prerequisite | Update GETTING_STARTED.md and post-destroy-grants runbook. Partially addressed by `docs/runbooks/post-destroy-grants.md`. |
 | [#84](https://github.com/nobhri/azure-dbx-mock-platform/issues/84) | HIGH | Preflight fix commit not merged into main — old buggy code still active | Fix pushed after PR #79 merged; dangling commit. PR #84 re-applies the fix. |
-| [#85](https://github.com/nobhri/azure-dbx-mock-platform/issues/85) | MEDIUM | UC catalog/schema not visible to human user — missing USE CATALOG/USE SCHEMA grants | Groups + grants now automated via platform-layer-rewrite PR. Remaining: human must join `data_platform_admins` group via CLI or GUI after workload-catalog runs. |
+| [#85](https://github.com/nobhri/azure-dbx-mock-platform/issues/85) | MEDIUM | UC catalog/schema not visible to human user — missing USE CATALOG/USE SCHEMA grants | GRANT step now resilient: warns on missing principals, does not fail. Groups must be created as account-level groups via Account Console or CLI (PR #97). Re-run workload-catalog after group creation. |
 | [#82](https://github.com/nobhri/azure-dbx-mock-platform/issues/82) | LOW | Test coverage gap: dynamic metastore import path not exercised in CI | Branch 3 ("Found existing metastore — importing") never triggered. Requires manual `terraform state rm` to test. See session-008 for procedure. |
 
 ---
@@ -26,7 +26,8 @@ These require direct human action in Azure, GitHub, or Databricks — cannot be 
 |--------|----------|-------|
 | Add OIDC federated credential for `pull_request` subject | MEDIUM | Entra ID → App Registration → Federated credentials |
 | After each destroy/recreate: run post-destroy grants (Step 1 — SP grants) | REQUIRED | Databricks SQL warehouse — see [runbook](runbooks/post-destroy-grants.md) |
-| After workload-catalog runs: add yourself to `data_platform_admins` group | ONE-TIME | Databricks CLI: `databricks groups add-member --group-name data_platform_admins --user-name <email>` or Account Console GUI |
+| Create account-level groups (data_platform_admins, data_engineers, data_consumers) | ONE-TIME | Databricks Account Console → User Management → Groups (see runbook Step 2) |
+| After group creation: re-run workload-catalog to apply deferred GRANTs | REQUIRED | GitHub Actions → workload-catalog → Run workflow |
 
 ---
 

--- a/platform/notebooks/setup_platform.py
+++ b/platform/notebooks/setup_platform.py
@@ -50,8 +50,14 @@ def load_yaml(filename):
         return yaml.safe_load(f)
 
 
-def render_and_execute(template_file, template_vars):
-    """Read a Jinja2 template, render it, and execute each SQL statement."""
+def render_and_execute(template_file, template_vars, warn_on_principal_missing=False):
+    """Read a Jinja2 template, render it, and execute each SQL statement.
+
+    If warn_on_principal_missing=True, statements that fail with
+    PRINCIPAL_DOES_NOT_EXIST emit a warning and continue rather than raising.
+    This is used for GRANT statements targeting groups that may not yet
+    exist as account-level principals in Unity Catalog.
+    """
     path = f"{templates_dir}/{template_file}"
     print(f"\n{'=' * 60}")
     print(f"Processing: {template_file}")
@@ -72,7 +78,15 @@ def render_and_execute(template_file, template_vars):
 
     for stmt in statements:
         print(f"\nExecuting:\n{stmt}\n")
-        spark.sql(stmt)
+        try:
+            spark.sql(stmt)
+        except Exception as e:
+            if warn_on_principal_missing and "PRINCIPAL_DOES_NOT_EXIST" in str(e):
+                print(f"WARNING: principal not found -- skipping grant.\n"
+                      f"  Create the group as an account-level group first.\n"
+                      f"  Details: {e}\n")
+            else:
+                raise
 
 # COMMAND ----------
 
@@ -113,48 +127,35 @@ render_and_execute("create_schema.sql.j2", {
 
 # COMMAND ----------
 
-# Step 3: CREATE GROUPS via SCIM REST API
-# CREATE GROUP is not a SQL statement -- groups are managed via the REST API.
-# Using requests (pre-installed on all DBR versions) instead of databricks-sdk
-# to avoid SDK version incompatibilities across DBR releases.
-# Idempotent: list existing groups first, skip any that already exist.
-import requests
-
-_ctx = dbutils.notebook.entry_point.getDbutils().notebook().getContext()
-_host = _ctx.apiUrl().get()
-_token = _ctx.apiToken().get()
-_headers = {"Authorization": f"Bearer {_token}", "Content-Type": "application/json"}
-_scim_base = f"{_host}/api/2.0/preview/scim/v2/Groups"
-
-_resp = requests.get(_scim_base, headers=_headers)
-_resp.raise_for_status()
-existing_group_names = {g["displayName"] for g in _resp.json().get("Resources", [])}
-
+# Step 3: Group prerequisite notice
+# Unity Catalog GRANT requires account-level groups, not workspace-local groups.
+# Workspace SCIM groups (created via /api/2.0/preview/scim/v2/Groups) are NOT
+# visible to UC GRANT -- they live in a different scope.
+# Account-level groups must be created manually via:
+#   - Databricks Account Console > Groups
+#   - Databricks CLI: databricks groups create --profile <account-profile>
+# This is the same pattern as SP grants (post-destroy-grants.md runbook).
+# Group names expected by the GRANT step:
 for group in groups_config["groups"]:
-    name = group["name"]
-    if name in existing_group_names:
-        print(f"Group already exists (skip): {name}")
-    else:
-        _r = requests.post(
-            _scim_base,
-            headers=_headers,
-            json={
-                "schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group"],
-                "displayName": name,
-            },
-        )
-        _r.raise_for_status()
-        print(f"Created group: {name}")
+    print(f"  Required account-level group: {group['name']}")
+print("\nIf any groups above do not exist at the account level, the GRANT step")
+print("below will skip those grants with a WARNING (not an error).")
+print("Re-run workload-catalog after creating the groups to apply all grants.")
 
 # COMMAND ----------
 
 # Step 4: GRANT PERMISSIONS
+# warn_on_principal_missing=True: skips grants for groups not yet created at
+# the account level. The job succeeds with a warning; re-run after group creation
+# to apply the skipped grants (all GRANT statements are idempotent).
 render_and_execute("grant_permissions.sql.j2", {
     "catalog": catalog,
     "catalog_grants": grants_config["catalog_grants"],
     "schema_grants": grants_config["schema_grants"],
-})
+}, warn_on_principal_missing=True)
 
 # COMMAND ----------
 
-print("Done -- all catalog, schema, group, and grant objects are in place.")
+print("Done -- catalog and schema objects are in place.")
+print("If WARNING lines appeared above, create the missing account-level groups")
+print("and re-run workload-catalog to apply the deferred grants.")


### PR DESCRIPTION
## Root cause

Unity Catalog `GRANT` requires **account-level groups**. Workspace-level SCIM groups (created via `/api/2.0/preview/scim/v2/Groups`) are invisible to UC — they exist in a different scope. This is a UC constraint, not a code bug.

The previous Step 3 was creating workspace-local groups, which succeeded, but the Step 4 GRANT then failed with:
```
PRINCIPAL_DOES_NOT_EXIST: Could not find principal with name data_platform_admins
```

## Changes

### `platform/notebooks/setup_platform.py`

**`render_and_execute()`** — added `warn_on_principal_missing` flag:
- When `True`, catches `PRINCIPAL_DOES_NOT_EXIST` and prints a `WARNING` instead of raising
- All other errors still raise immediately

**Step 3** — removed workspace SCIM group creation (wrong scope):
- Replaced with a prerequisite notice that lists the required account-level group names
- Account-level groups must be created manually via Account Console or CLI (same pattern as SP grants)

**Step 4** — GRANT step now uses `warn_on_principal_missing=True`:
- Job succeeds even if groups don't exist yet
- Deferred grants are applied on re-run after group creation (all GRANTs are idempotent)

### `docs/runbooks/post-destroy-grants.md`

Step 2 rewritten: documents account-level group creation via Account Console or Databricks CLI. Explains the re-run pattern.

### `docs/status.md`

Pending actions updated to reflect the correct group creation procedure.

## Design note

Account-level group creation requires human involvement (Account Console or CLI with account-level profile). This mirrors the SP grants pattern and is consistent with ADR-005's statement that group membership is managed outside the repository. The GRANT automation remains intact — it just defers gracefully when groups aren't ready.

## Test plan

- [ ] `workload-catalog` CI run on main succeeds (no exception at Step 4)
- [ ] WARNING lines appear in run output for missing groups (not ERROR)
- [ ] After creating account-level groups manually and re-running, all GRANTs apply
- [ ] `SHOW GRANTS ON CATALOG mock` confirms grants are in place

🤖 Generated with [Claude Code](https://claude.com/claude-code)