### PR TITLE
docs: update status.md and session note for doc review (issues #105–#112)

### DIFF
--- a/docs/sessions/2026-03-09-001-doc-review-issues.md
+++ b/docs/sessions/2026-03-09-001-doc-review-issues.md
@@ -1,0 +1,73 @@
+# Session: Documentation Review & Issue Creation
+
+**Date:** 2026-03-09
+**Branch:** docs/status-doc-review-2026-03-09
+**Session type:** Documentation audit + issue triage
+
+---
+
+## Objective
+
+Full review of README.md, CLAUDE.md, GETTING_STARTED.md, and all files under `docs/` from
+three audience perspectives: owner, AI agent, and external repo audience. Issues created for
+all findings.
+
+---
+
+## Scope Reviewed
+
+- `README.md`
+- `CLAUDE.md`
+- `GETTING_STARTED.md`
+- `docs/adr/` (all 5 ADRs)
+- `docs/design/platform-layer.md`
+- `docs/runbooks/` (all 3 runbooks)
+- `docs/proposals/` (README + all 6 proposals)
+- `docs/status.md`
+- `docs/sessions/` (structure, not content)
+
+---
+
+## Findings & Issues Created
+
+### HIGH severity
+
+| Issue | Finding |
+|-------|---------|
+| [#105](https://github.com/nobhri/azure-dbx-mock-platform/issues/105) | README "Current Status" and "Known Issues" are stale — completed items listed as in-progress; known-issues diverges from `status.md` |
+| [#106](https://github.com/nobhri/azure-dbx-mock-platform/issues/106) | GETTING_STARTED.md prerequisites table missing `ADLS_STORAGE_NAME`; stale `METASTORE_ID` still listed (removed in PR #81) |
+| [#107](https://github.com/nobhri/azure-dbx-mock-platform/issues/107) | `post-destroy-grants.md` verification SQL references nonexistent group `databricks-platform-users` — should be `data_platform_admins` |
+
+### MEDIUM severity
+
+| Issue | Finding |
+|-------|---------|
+| [#108](https://github.com/nobhri/azure-dbx-mock-platform/issues/108) | README "Production Considerations" section (~100 lines) makes README too long; extract to `docs/design/production-considerations.md` |
+| [#109](https://github.com/nobhri/azure-dbx-mock-platform/issues/109) | No explicit Phase 2 roadmap in README — project looks "done but incomplete" to external audience |
+| [#110](https://github.com/nobhri/azure-dbx-mock-platform/issues/110) | Architecture layer diagram has no ADR cross-references — reader must manually map layers to ADRs |
+| [#111](https://github.com/nobhri/azure-dbx-mock-platform/issues/111) | `status.md` not linked from README; `docs/sessions/` has no README explaining what session files are |
+
+### LOW severity
+
+| Issue | Finding |
+|-------|---------|
+| [#112](https://github.com/nobhri/azure-dbx-mock-platform/issues/112) | PR #70 is open but the restructure it proposes was already implemented in PR #71; five proposals stuck "Proposed" since 2026-03-05 with no priority signal |
+
+---
+
+## Observations
+
+- ADRs are the strongest part of the documentation — well-structured, rejected alternatives are
+  documented, consequences are explicit. ADR-005 updated 2026-03-07 is particularly thorough.
+- `docs/design/platform-layer.md` effectively bridges ADR-level rationale and implementation-level
+  decisions — rare and valuable for an audience evaluating design maturity.
+- `docs/proposals/` lifecycle (Proposed → Accepted → Closed/Rejected) is a good system, but five
+  proposals in "Proposed" state with no dates for resolution look stale from the outside.
+- `post-destroy-grants.md` is the most operationally critical runbook; the wrong group name in the
+  verification step (issue #107) is the highest-risk factual error found.
+
+---
+
+## No Code Changes This Session
+
+All changes are documentation only. No Terraform, workflow, or notebook files were modified.

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,6 +1,6 @@
 # Project Status Snapshot
 
-**Last updated:** 2026-03-09
+**Last updated:** 2026-03-09 (session 001 — doc review)
 **Update instructions:** Edit this file at the end of each docs PR. Update any issue that was
 opened, closed, or changed severity during the session.
 
@@ -14,6 +14,14 @@ opened, closed, or changed severity during the session.
 | [#53](https://github.com/nobhri/azure-dbx-mock-platform/issues/53) | LOW | Document GRANT CREATE CATALOG prerequisite | Update GETTING_STARTED.md and post-destroy-grants runbook. Partially addressed by `docs/runbooks/post-destroy-grants.md`. |
 | [#82](https://github.com/nobhri/azure-dbx-mock-platform/issues/82) | LOW | Test coverage gap: dynamic metastore import path not exercised in CI | Branch 3 ("Found existing metastore — importing") never triggered. Requires manual `terraform state rm` to test. See session-008 for procedure. |
 | [#11](https://github.com/nobhri/azure-dbx-mock-platform/issues/11) | LOW | Add tflint step to workload-azure.yaml and workload-dbx.yaml | Enhancement blocked historically by OIDC issue #40. |
+| [#105](https://github.com/nobhri/azure-dbx-mock-platform/issues/105) | HIGH | README Current Status and Known Issues stale vs status.md | "In Progress" items are done; Known Issues section diverges from this file. |
+| [#106](https://github.com/nobhri/azure-dbx-mock-platform/issues/106) | HIGH | GETTING_STARTED.md prerequisites table has wrong secrets | Missing `ADLS_STORAGE_NAME`; stale `METASTORE_ID` still listed (removed by PR #81). |
+| [#107](https://github.com/nobhri/azure-dbx-mock-platform/issues/107) | HIGH | post-destroy-grants.md verification SQL references wrong group name | `databricks-platform-users` should be `data_platform_admins`. |
+| [#108](https://github.com/nobhri/azure-dbx-mock-platform/issues/108) | MEDIUM | Extract Production Considerations from README to docs/design/ | README is too long; prod-considerations content belongs in design doc. |
+| [#109](https://github.com/nobhri/azure-dbx-mock-platform/issues/109) | MEDIUM | Add Phase 2 roadmap section to README | Project looks "done but incomplete" to external audience; no visible next-step plan. |
+| [#110](https://github.com/nobhri/azure-dbx-mock-platform/issues/110) | MEDIUM | Add ADR annotations to README architecture diagram | Layer diagram has no cross-references to ADRs; reader must map manually. |
+| [#111](https://github.com/nobhri/azure-dbx-mock-platform/issues/111) | MEDIUM | Improve discoverability — link status.md, add sessions/ README | status.md not linked from README; sessions/ has no explanation for external readers. |
+| [#112](https://github.com/nobhri/azure-dbx-mock-platform/issues/112) | LOW | Close stale PR #70 and triage proposed-state proposals | PR #70 open but already implemented in #71; 5 proposals stuck "Proposed" since 2026-03-05. |
 
 ---
 
@@ -25,6 +33,7 @@ These require direct human action in Azure, GitHub, or Databricks — cannot be 
 |--------|----------|-------|
 | Add OIDC federated credential for `pull_request` subject | MEDIUM | Entra ID → App Registration → Federated credentials |
 | After each destroy/recreate: run post-destroy grants (Step 1 — SP grants) | REQUIRED | Databricks SQL warehouse — see [runbook](runbooks/post-destroy-grants.md) |
+| Close PR #70 (docs-restructure proposal — already implemented in PR #71) | LOW | GitHub — AI agent cannot close PRs per CLAUDE.md |
 
 ---
 


### PR DESCRIPTION
## Summary

- Updates `docs/status.md` to include 8 new issues (#105–#112) opened during the documentation structure review session, and adds a pending human action for closing stale PR #70
- Creates `docs/sessions/2026-03-09-001-doc-review-issues.md` with the full session summary — scope reviewed, findings table by severity, and key observations

## Issues Tracked

| Issue | Severity | Topic |
|-------|----------|-------|
| refs #105 | HIGH | README Current Status/Known Issues stale |
| refs #106 | HIGH | GETTING_STARTED.md prerequisites wrong secrets |
| refs #107 | HIGH | post-destroy-grants.md wrong group name in verification SQL |
| refs #108 | MEDIUM | Extract Production Considerations from README |
| refs #109 | MEDIUM | Add Phase 2 roadmap to README |
| refs #110 | MEDIUM | ADR annotations on architecture diagram |
| refs #111 | MEDIUM | status.md discoverability + sessions/ README |
| refs #112 | LOW | Stale PR #70 + triage proposals |

## No functional changes

Documentation files only (`docs/status.md`, new session file). No code, workflow, or Terraform changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)