### PR TITLE
docs: update README Current Status — sync with status.md (#105)

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,20 +280,19 @@ In a multi-Storage-Account setup, NCC configuration must be repeated for each ac
 
 - Azure infrastructure provisioned via Terraform
 - Databricks Workspace + Unity Catalog Metastore configured
+- Catalog/Schema management via Jinja2 + Python Notebook (workload-catalog confirmed accessible 2026-03-08)
+- Asset Bundles with environment-specific targets (`dev`, `staging`, `prod`)
+- SDLC variable parametrization across environments
+- GitHub Actions Workflow Dispatch for `dev`/`staging`
+- ADR documentation (5 ADRs)
 
 ### In Progress
 
-- Asset Bundles with environment-specific targets (`dev`, `staging`, `prod`)
-- SDLC variable parametrization across environments
 - MVP ETL pipeline using `saveAsTable`
-- Catalog/Schema management via Jinja2 + Python Notebook (replacing Terraform-managed catalog)
-- GitHub Actions Workflow Dispatch for `dev`/`staging`
-- ADR documentation
 - README finalization for public release
 
 ### Known Issues
 
-- `go-task` runner abstraction became complex; CI/CD integration needs simplification
 - **Destroy order matters:** Always destroy `workload-dbx` before `workload-azure`. Destroying Azure first leaves Unity Catalog account-scope objects (`uc-mi-credential`, `uc-root-location`) orphaned. `force_destroy = true` on the metastore (PR [#50](https://github.com/nobhri/azure-dbx-mock-platform/pull/50)) now cascade-deletes notebook-created catalogs automatically — manual UC cleanup is no longer required when the correct destroy order is followed.
 - **Post-destroy manual grants required:** After each full destroy + recreate cycle, the metastore admin must re-run both grants manually (the SP cannot self-grant account-level UC privileges):
   - `GRANT CREATE EXTERNAL LOCATION ON METASTORE TO '<SP_client_id>';`

--- a/docs/sessions/2026-03-10-001-readme-status-105.md
+++ b/docs/sessions/2026-03-10-001-readme-status-105.md
@@ -1,0 +1,32 @@
+# Session Note — 2026-03-10-001 — README Current Status fix (#105)
+
+**Issue:** [#105](https://github.com/nobhri/azure-dbx-mock-platform/issues/105) — README "Current Status (MVP)" stale vs status.md
+**Branch:** `docs/readme-status-105`
+**Worktree:** `.claude/worktrees/docs/readme-status-105`
+
+## Problem
+
+The README `## Current Status (MVP)` section had two problems:
+1. Several "In Progress" items were already complete (Catalog/Schema DDL, Asset Bundles, ADRs, etc.)
+2. "Known Issues" had a stale entry (`go-task` complexity note) with no corresponding open issue in status.md
+
+## Changes Made
+
+### README.md — Current Status (MVP)
+
+- **Done section** — added items completed in previous sessions:
+  - Catalog/Schema management via Jinja2 + Python Notebook (PR #54, workload-catalog confirmed 2026-03-08)
+  - Asset Bundles with environment-specific targets (dev/staging/prod)
+  - SDLC variable parametrization across environments (PR #65)
+  - GitHub Actions Workflow Dispatch for dev/staging
+  - ADR documentation (5 ADRs documented)
+
+- **In Progress section** — kept only items still open:
+  - MVP ETL pipeline using `saveAsTable`
+  - README finalization for public release
+
+- **Known Issues section** — removed stale `go-task` complexity note (no corresponding open issue in status.md); remaining items aligned with status.md open issues
+
+## Status
+
+PR created — waiting for human review.


### PR DESCRIPTION
## Summary

- Moves completed "In Progress" items to "Done": Catalog/Schema DDL, Asset Bundles, SDLC parametrization, GitHub Actions Workflow Dispatch, ADR documentation
- Removes stale `go-task` complexity entry from Known Issues (no corresponding open issue in status.md)
- Remaining Known Issues section now aligned with `docs/status.md`

## Test plan

- [ ] Verify README `## Current Status (MVP)` Done/In Progress/Known Issues sections match `docs/status.md`
- [ ] Confirm no open issues are missing from Known Issues

refs #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)