### PR TITLE
fix: correct group name in post-destroy-grants verification SQL

### DIFF
--- a/docs/runbooks/post-destroy-grants.md
+++ b/docs/runbooks/post-destroy-grants.md
@@ -152,7 +152,7 @@ SHOW GRANTS ON METASTORE;
 After Step 2 grants:
 ```sql
 SHOW GRANTS ON CATALOG <catalog_name>;
--- Confirm databricks-platform-users appears with USE CATALOG
+-- Confirm data_platform_admins appears with USE CATALOG
 ```
 
 ---

--- a/docs/sessions/2026-03-10-001-post-destroy-grants-107.md
+++ b/docs/sessions/2026-03-10-001-post-destroy-grants-107.md
@@ -1,0 +1,21 @@
+# Session 2026-03-10-001 — Fix wrong group name in post-destroy-grants.md (#107)
+
+**Date:** 2026-03-10
+**Branch:** fix/post-destroy-grants-107
+**Issue:** [#107](https://github.com/nobhri/azure-dbx-mock-platform/issues/107)
+
+## Change
+
+Fixed wrong group name in the Verification section of `docs/runbooks/post-destroy-grants.md`.
+
+The SQL comment after `SHOW GRANTS ON CATALOG` referenced `databricks-platform-users`, which was
+a stale/incorrect group name. The correct account-level group created by the platform layer is
+`data_platform_admins`.
+
+**File:** `docs/runbooks/post-destroy-grants.md` line 155
+**Before:** `-- Confirm databricks-platform-users appears with USE CATALOG`
+**After:** `-- Confirm data_platform_admins appears with USE CATALOG`
+
+## Status at session end
+
+No issues opened or closed. Issue #107 is pending human review and manual close after PR merge.


### PR DESCRIPTION
## Summary

- Fixes wrong group name in `docs/runbooks/post-destroy-grants.md` Verification section
- The SQL comment after `SHOW GRANTS ON CATALOG` referenced `databricks-platform-users` (stale/never-existed name)
- Correct account-level group is `data_platform_admins` (created by the platform layer)

refs #107

## Test plan

- [ ] Review the diff — one-line comment fix, no executable code changed
- [ ] Verify `data_platform_admins` matches group names in Step 2 of the same runbook (lines 57, 61, 62, 92, 97)
- [ ] Close #107 manually after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)