### PR TITLE
docs: extract Production Considerations from README to docs/design/

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,75 +202,13 @@ See [ADR-005](docs/adr/005-group-permissions.md) for full rationale.
 
 ## Production Considerations
 
-> These topics are **not implemented in this mock environment** due to cost and complexity constraints. They are documented here to demonstrate awareness of what a production-grade enterprise deployment requires.
+These topics are not implemented in this mock environment due to cost and complexity constraints.
+They are documented to demonstrate awareness of what a production-grade enterprise deployment
+requires. Topics covered: VNet-per-workspace and hub-and-spoke topology, Storage Account
+architecture (single vs multiple), and Serverless compute Network Connectivity Configuration (NCC).
 
-### Network Isolation
-
-#### VNet per Workspace
-
-Each Databricks workspace requires its own VNet (or dedicated subnet range). In a multi-workspace architecture (dev / staging / prod / biz), this means managing multiple VNets and their peering relationships.
-
-#### Hub-and-Spoke Topology
-
-For enterprise environments connected to a corporate network, a hub-and-spoke model is typical:
-
-- A shared hub VNet handles connectivity to on-premises or corporate networks (via ExpressRoute or VPN Gateway)
-- Each workspace VNet is a spoke, peered to the hub
-- All egress traffic routes through the hub for inspection and control
-
-This adds significant setup effort but is usually non-negotiable in large organizations with existing network governance.
-
-#### VNet Injection Scope — A Common Oversight
-
-VNet Injection controls where compute nodes (clusters, Serverless) are deployed — it does not cover the Databricks Control Plane (Workspace UI, API, Job scheduler), which is a Databricks-managed SaaS endpoint. To restrict access to the Control Plane, a separate measure is required: either an IP Allowlist or Azure Private Link for the Control Plane endpoint. Treating VNet Injection alone as "network isolation complete" is a common oversight.
-
-#### CI/CD Impact
-
-Network isolation has a direct impact on CI/CD execution. GitHub-hosted runners operate from dynamic IPs and cannot reach a network-isolated workspace by default. Two options:
-
-- **GitHub-hosted runner + IP allowlist**: Assign a static IP to the runner (via a NAT Gateway or similar) and add it to the Workspace IP access list
-- **Self-hosted runner**: Deploy a runner inside the VNet — full network access, but adds operational overhead for runner maintenance
-
-Neither option is free. Factor this in when deciding how aggressively to isolate the workspace network.
-
------
-
-### Storage Account Architecture
-
-Storage Account architecture is the most consequential infrastructure decision in a Unity Catalog deployment — and the right answer depends on organizational requirements.
-
-**Decision tree:**
-
-```
-Q: Can all Unity Catalog data live in a single Storage Account?
-│
-├─ Yes (cost simplicity, single team, uniform redundancy acceptable)
-│   └─ Single Storage Account + VNet Injection
-│       ✓ One Private Endpoint to manage
-│       ✓ Simpler NCC configuration if using Serverless compute
-│       ✗ No per-team cost attribution at Storage layer
-│       ✗ Redundancy level (LRS / ZRS / GRS) unified across all data
-│
-└─ No (team-level cost separation needed, or Prod requires higher redundancy)
-    └─ Multiple Storage Accounts
-        ✓ Cost attribution per team or environment
-        ✓ GRS for Prod, LRS for dev/staging (cost optimization)
-        ✗ Private Endpoint required per Storage Account
-        ✗ NCC configuration multiplies with each account
-        ✗ Operational overhead increases significantly
-```
-
-**Recommendation:** Default to a single Storage Account unless there is a clear organizational requirement for cost separation or differential redundancy. The operational cost of managing multiple Private Endpoints and NCC configurations is frequently underestimated.
-
------
-
-### Serverless Compute & Network Configuration (NCC)
-
-If Serverless compute is used (increasingly common as the default for jobs and SQL warehouses), **Network Connectivity Configuration (NCC)** must be explicitly set up to allow Serverless nodes to reach the Storage Account via Private Endpoint.
-
-This is a common oversight: classic compute (with VNet Injection) reaches Storage through the injected VNet, but Serverless compute runs outside the customer VNet by default. Without NCC, Serverless jobs will fail to access Storage even if the rest of the network config is correct.
-
-In a multi-Storage-Account setup, NCC configuration must be repeated for each account — another reason to prefer a single Storage Account where possible.
+See [`docs/design/production-considerations.md`](docs/design/production-considerations.md) for
+the full write-up.
 
 -----
 

--- a/docs/design/production-considerations.md
+++ b/docs/design/production-considerations.md
@@ -1,0 +1,98 @@
+# Design: Production Considerations
+
+> These topics are **not implemented in this mock environment** due to cost and complexity
+> constraints. They are documented here to demonstrate awareness of what a production-grade
+> enterprise deployment requires.
+>
+> For implementation-level decisions actually made in this repository, see
+> [`docs/design/platform-layer.md`](platform-layer.md).
+
+---
+
+## Network Isolation
+
+### VNet per Workspace
+
+Each Databricks workspace requires its own VNet (or dedicated subnet range). In a
+multi-workspace architecture (dev / staging / prod / biz), this means managing multiple VNets
+and their peering relationships.
+
+### Hub-and-Spoke Topology
+
+For enterprise environments connected to a corporate network, a hub-and-spoke model is typical:
+
+- A shared hub VNet handles connectivity to on-premises or corporate networks (via ExpressRoute
+  or VPN Gateway)
+- Each workspace VNet is a spoke, peered to the hub
+- All egress traffic routes through the hub for inspection and control
+
+This adds significant setup effort but is usually non-negotiable in large organizations with
+existing network governance.
+
+### VNet Injection Scope — A Common Oversight
+
+VNet Injection controls where compute nodes (clusters, Serverless) are deployed — it does not
+cover the Databricks Control Plane (Workspace UI, API, Job scheduler), which is a
+Databricks-managed SaaS endpoint. To restrict access to the Control Plane, a separate measure
+is required: either an IP Allowlist or Azure Private Link for the Control Plane endpoint.
+Treating VNet Injection alone as "network isolation complete" is a common oversight.
+
+### CI/CD Impact
+
+Network isolation has a direct impact on CI/CD execution. GitHub-hosted runners operate from
+dynamic IPs and cannot reach a network-isolated workspace by default. Two options:
+
+- **GitHub-hosted runner + IP allowlist**: Assign a static IP to the runner (via a NAT Gateway
+  or similar) and add it to the Workspace IP access list
+- **Self-hosted runner**: Deploy a runner inside the VNet — full network access, but adds
+  operational overhead for runner maintenance
+
+Neither option is free. Factor this in when deciding how aggressively to isolate the workspace
+network.
+
+---
+
+## Storage Account Architecture
+
+Storage Account architecture is the most consequential infrastructure decision in a Unity
+Catalog deployment — and the right answer depends on organizational requirements.
+
+**Decision tree:**
+
+```
+Q: Can all Unity Catalog data live in a single Storage Account?
+│
+├─ Yes (cost simplicity, single team, uniform redundancy acceptable)
+│   └─ Single Storage Account + VNet Injection
+│       ✓ One Private Endpoint to manage
+│       ✓ Simpler NCC configuration if using Serverless compute
+│       ✗ No per-team cost attribution at Storage layer
+│       ✗ Redundancy level (LRS / ZRS / GRS) unified across all data
+│
+└─ No (team-level cost separation needed, or Prod requires higher redundancy)
+    └─ Multiple Storage Accounts
+        ✓ Cost attribution per team or environment
+        ✓ GRS for Prod, LRS for dev/staging (cost optimization)
+        ✗ Private Endpoint required per Storage Account
+        ✗ NCC configuration multiplies with each account
+        ✗ Operational overhead increases significantly
+```
+
+**Recommendation:** Default to a single Storage Account unless there is a clear organizational
+requirement for cost separation or differential redundancy. The operational cost of managing
+multiple Private Endpoints and NCC configurations is frequently underestimated.
+
+---
+
+## Serverless Compute & Network Configuration (NCC)
+
+If Serverless compute is used (increasingly common as the default for jobs and SQL warehouses),
+**Network Connectivity Configuration (NCC)** must be explicitly set up to allow Serverless
+nodes to reach the Storage Account via Private Endpoint.
+
+This is a common oversight: classic compute (with VNet Injection) reaches Storage through the
+injected VNet, but Serverless compute runs outside the customer VNet by default. Without NCC,
+Serverless jobs will fail to access Storage even if the rest of the network config is correct.
+
+In a multi-Storage-Account setup, NCC configuration must be repeated for each account — another
+reason to prefer a single Storage Account where possible.

--- a/docs/sessions/2026-03-10-003-prod-considerations-108.md
+++ b/docs/sessions/2026-03-10-003-prod-considerations-108.md
@@ -1,0 +1,23 @@
+# Session: 2026-03-10-003 — Extract Production Considerations (#108)
+
+**Date:** 2026-03-10
+**Branch:** docs/prod-considerations-108
+**Issue:** refs #108
+
+## What was done
+
+- Created `docs/design/production-considerations.md` with the full content previously in the
+  README "Production Considerations" section (Network Isolation, Storage Account Architecture,
+  Serverless Compute & NCC).
+- Replaced the verbose README section with a 4-line summary and a link to the new design doc.
+
+## Why
+
+The README "Production Considerations" section was ~70 lines of detail that made the README
+harder to skim. Design-level detail belongs in `docs/design/`, alongside `platform-layer.md`.
+The README now provides a summary and directs readers to the full doc.
+
+## Files changed
+
+- `docs/design/production-considerations.md` — new file (extracted content)
+- `README.md` — Production Considerations section replaced with summary + link


### PR DESCRIPTION
## Summary

- Moved the ~70-line Production Considerations section (Network Isolation, Storage Account Architecture, Serverless Compute / NCC) from `README.md` into a new file `docs/design/production-considerations.md`
- Replaced the verbose README section with a 4-line summary and a link to the new design doc
- Added session note `docs/sessions/2026-03-10-003-prod-considerations-108.md`

## Test plan

- [ ] Verify README renders cleanly with the new summary block
- [ ] Verify the link `docs/design/production-considerations.md` resolves correctly on GitHub
- [ ] Confirm all content is present in the new design doc (no content lost)

refs #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)