### PR TITLE
docs: link status.md from README; add sessions/ README

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,8 @@ In a multi-Storage-Account setup, NCC configuration must be repeated for each ac
 
 ## Current Status (MVP)
 
+> **Live tracking:** [`docs/status.md`](docs/status.md) is the authoritative snapshot of open issues, pending actions, and architecture state. The section below is a high-level summary.
+
 ### Done
 
 - Azure infrastructure provisioned via Terraform

--- a/docs/sessions/2026-03-10-003-discoverability-111.md
+++ b/docs/sessions/2026-03-10-003-discoverability-111.md
@@ -1,0 +1,22 @@
+# Session 2026-03-10-003 — Discoverability (Issue #111)
+
+## Goal
+
+Issue #111: Improve discoverability — link `docs/status.md` from README; add `docs/sessions/README.md` for external readers.
+
+## Changes
+
+### README.md
+
+Added a callout block at the top of the "Current Status (MVP)" section pointing readers to `docs/status.md` as the authoritative live tracking document.
+
+### docs/sessions/README.md (new)
+
+Created a README explaining:
+- What session notes are and are not (working log, not polished docs)
+- Naming convention (`YYYY-MM-DD-NNN-slug.md`)
+- Relationship to `docs/status.md` and `docs/adr/`
+
+## Outcome
+
+Both changes are minimal and non-breaking. No content was removed or restructured.

--- a/docs/sessions/README.md
+++ b/docs/sessions/README.md
@@ -1,0 +1,34 @@
+# Session Notes
+
+This directory contains per-session working notes created during development of the Databricks Mock Platform.
+
+## Purpose
+
+Each file records what was decided, attempted, or discovered in a single working session. They are **not polished documentation** — they are an honest log of the work as it happened, including dead ends and course corrections.
+
+For external readers, session notes show:
+- How architectural decisions evolved over time
+- The reasoning behind mid-session pivots
+- What problems were encountered and how they were resolved
+
+## Naming Convention
+
+```
+YYYY-MM-DD-NNN-slug.md
+```
+
+- `YYYY-MM-DD` — date of the session
+- `NNN` — zero-padded sequence within that date (001, 002, ...)
+- `slug` — short description of the session's focus
+
+**Example:** `2026-03-06-007-issue-80-dynamic-metastore-import.md`
+
+## Relationship to Other Docs
+
+| Document | Purpose |
+|----------|---------|
+| [`docs/status.md`](../status.md) | Live snapshot of open issues and architecture state |
+| [`docs/adr/`](../adr/) | Durable architectural decisions (ADRs) |
+| `docs/sessions/` | Working notes — context behind decisions, not the decisions themselves |
+
+Session notes inform ADRs, not the other way around. If a session note leads to a stable decision, that decision is captured in an ADR or runbook.


### PR DESCRIPTION
## Summary

- Add a callout block at the top of the "Current Status (MVP)" section in README.md, pointing readers to `docs/status.md` as the authoritative live tracking document
- Create `docs/sessions/README.md` explaining the purpose of session notes, the naming convention, and their relationship to `docs/status.md` and `docs/adr/`

refs #111

## Test plan

- [ ] Verify the `docs/status.md` link in README renders correctly on GitHub
- [ ] Verify `docs/sessions/README.md` renders correctly and all relative links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)