### PR TITLE
docs: add Phase 2 roadmap section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,48 @@ In a multi-Storage-Account setup, NCC configuration must be repeated for each ac
 
 -----
 
+## Phase 2 Roadmap
+
+> These items represent the planned next phase of development. Phase 1 (MVP) established the foundational layer separation, CI/CD discipline, and governance baseline. Phase 2 expands the platform toward a realistic multi-workspace, multi-team operating model.
+
+### Developer Experience
+
+| Item | Description |
+|------|-------------|
+| Local `bundle run` in `dev` | Enable via VS Code Databricks extension scoped to per-developer namespaces (isolated catalog/schema per developer). Eliminates environment collision risk while improving iteration speed. See [CI/CD Design](#cicd-design) for Phase 1 rationale. |
+| Per-developer namespace isolation | Each developer gets a dedicated catalog/schema prefix in `dev` — prevents shared state collisions during local iteration. |
+
+### Multi-Workspace Expansion
+
+| Item | Description |
+|------|-------------|
+| `staging` workspace | Add a dedicated staging workspace and catalog. Currently only `dev` and `prod` targets exist in Asset Bundles. |
+| `prod` workspace separation | Promote prod to a dedicated workspace (currently same workspace as dev, separated by catalog only). |
+| Consumer workspace | Deploy the consumer workspace described in [ADR-004](docs/adr/004-consumer-access.md) — a separate workspace with a View layer over the prod catalog for business consumers. |
+
+### Identity & Governance
+
+| Item | Description |
+|------|-------------|
+| EntraID Native Sync | Replace Databricks-native groups with EntraID-synced groups. Native Sync supports nested groups and simplifies offboarding propagation. See [ADR-005](docs/adr/005-group-permissions.md). |
+| Table/View DDL Layer | Implement the Jinja2 DDL layer for table and view definitions, currently shown as "planned" in the architecture diagram. Owned by the Data Engineering team. |
+
+### Network & Security
+
+| Item | Description |
+|------|-------------|
+| Private Endpoint for Storage | Add Azure Private Endpoint for the ADLS Storage Account (currently accessible over public endpoint with RBAC). |
+| NCC for Serverless compute | Configure Network Connectivity Configuration to allow Serverless nodes to reach Storage via Private Endpoint. See [Production Considerations — Serverless Compute](#serverless-compute--network-configuration-ncc). |
+
+### Observability
+
+| Item | Description |
+|------|-------------|
+| Audit log pipeline | Forward Databricks audit logs to ADLS via Diagnostic Settings. Baseline for compliance and access review. |
+| Job run history retention | Define a retention and export policy for GitHub Actions run logs and Databricks job run history. |
+
+-----
+
 ## Blog Series
 
 Detailed write-ups on specific decisions:

--- a/docs/sessions/2026-03-10-003-phase2-roadmap-109.md
+++ b/docs/sessions/2026-03-10-003-phase2-roadmap-109.md
@@ -1,0 +1,27 @@
+# Session 2026-03-10-003 — Phase 2 Roadmap (Issue #109)
+
+**Date:** 2026-03-10
+**Branch:** docs/phase2-roadmap-109
+**Issue:** refs #109
+
+## Goal
+
+Add a Phase 2 roadmap section to README.md so external readers can see the planned next steps beyond the MVP.
+
+## Changes
+
+- `README.md`: Added `## Phase 2 Roadmap` section between "Current Status (MVP)" and "Blog Series"
+
+## Roadmap items added
+
+Four categories:
+
+1. **Developer Experience** — local `bundle run` in `dev` via VS Code extension; per-developer namespace isolation
+2. **Multi-Workspace Expansion** — `staging` workspace, dedicated `prod` workspace, consumer workspace (ADR-004)
+3. **Identity & Governance** — EntraID Native Sync (ADR-005), Table/View DDL Layer
+4. **Network & Security** — Private Endpoint for Storage, NCC for Serverless compute
+5. **Observability** — Audit log pipeline, job run history retention
+
+## Status
+
+PR created. Awaiting human review.


### PR DESCRIPTION
## Summary

- Adds `## Phase 2 Roadmap` section to README between "Current Status (MVP)" and "Blog Series"
- Four categories: Developer Experience, Multi-Workspace Expansion, Identity & Governance, Network & Security, plus Observability
- Each item is a table row with a short description; cross-links to ADRs and Production Considerations where relevant

## Motivation

Issue #109: the repository looks "done but incomplete" to external readers — there is no visible signal of planned next steps. This section gives portfolio reviewers and collaborators a clear picture of where the platform is heading.

## Test plan

- [ ] Verify `## Phase 2 Roadmap` renders correctly in GitHub Markdown preview
- [ ] Check ADR links (ADR-004, ADR-005) resolve correctly
- [ ] Check internal anchor link `#cicd-design` resolves correctly

refs #109