### PR TITLE
docs: triage 5 stale Proposed data engineering proposals to Accepted

### DIFF
--- a/docs/proposals/README.md
+++ b/docs/proposals/README.md
@@ -41,8 +41,8 @@ Proposed → Accepted → Closed      (implemented or superseded by a design doc
 
 | File | Title | Status | Date |
 |------|-------|--------|------|
-| [etl-overwrite-pattern.md](etl-overwrite-pattern.md) | ETL Overwrite Pattern | Proposed | 2026-03-05 |
-| [testing-strategy.md](testing-strategy.md) | Testing Strategy | Proposed | 2026-03-05 |
-| [code-design-transform-separation.md](code-design-transform-separation.md) | Code Design — Transform/Pipeline Separation | Proposed | 2026-03-05 |
-| [sdlc-catalog-lookup.md](sdlc-catalog-lookup.md) | SDLC Catalog Lookup | Proposed | 2026-03-05 |
-| [wheel-packaging.md](wheel-packaging.md) | Wheel Packaging | Proposed | 2026-03-05 |
+| [etl-overwrite-pattern.md](etl-overwrite-pattern.md) | ETL Overwrite Pattern | Accepted — Phase 2 data engineering; ADR-006 candidate pending | 2026-03-05 |
+| [testing-strategy.md](testing-strategy.md) | Testing Strategy | Accepted — Phase 2 data engineering | 2026-03-05 |
+| [code-design-transform-separation.md](code-design-transform-separation.md) | Code Design — Transform/Pipeline Separation | Accepted — Phase 2 data engineering | 2026-03-05 |
+| [sdlc-catalog-lookup.md](sdlc-catalog-lookup.md) | SDLC Catalog Lookup | Accepted — Phase 2 data engineering | 2026-03-05 |
+| [wheel-packaging.md](wheel-packaging.md) | Wheel Packaging | Accepted — Phase 2 data engineering; ADR-007 candidate pending | 2026-03-05 |

--- a/docs/proposals/code-design-transform-separation.md
+++ b/docs/proposals/code-design-transform-separation.md
@@ -1,6 +1,6 @@
 # Proposal: Code Design — Transform/Pipeline Separation
 
-**Status:** Proposed
+**Status:** Accepted — Phase 2 data engineering
 **Date:** 2026-03-05
 **Layer:** Data Engineering
 

--- a/docs/proposals/etl-overwrite-pattern.md
+++ b/docs/proposals/etl-overwrite-pattern.md
@@ -1,6 +1,6 @@
 # Proposal: ETL Overwrite Pattern
 
-**Status:** Proposed
+**Status:** Accepted — Phase 2 data engineering; ADR-006 candidate pending
 **Date:** 2026-03-05
 **Layer:** Data Engineering
 **Related ADRs:** ADR-003 (idempotency)

--- a/docs/proposals/sdlc-catalog-lookup.md
+++ b/docs/proposals/sdlc-catalog-lookup.md
@@ -1,6 +1,6 @@
 # Proposal: SDLC Catalog Lookup
 
-**Status:** Proposed
+**Status:** Accepted — Phase 2 data engineering
 **Date:** 2026-03-05
 **Layer:** Data Engineering
 **Related ADRs:** ADR-001 (Terraform scope)

--- a/docs/proposals/testing-strategy.md
+++ b/docs/proposals/testing-strategy.md
@@ -1,6 +1,6 @@
 # Proposal: Testing Strategy
 
-**Status:** Proposed
+**Status:** Accepted — Phase 2 data engineering
 **Date:** 2026-03-05
 **Layer:** Data Engineering
 **Related ADRs:** ADR-003 (idempotency)

--- a/docs/proposals/wheel-packaging.md
+++ b/docs/proposals/wheel-packaging.md
@@ -1,6 +1,6 @@
 # Proposal: Wheel Packaging
 
-**Status:** Proposed
+**Status:** Accepted — Phase 2 data engineering; ADR-007 candidate pending
 **Date:** 2026-03-05
 **Layer:** Data Engineering
 

--- a/docs/sessions/2026-03-10-003-proposals-triage-112.md
+++ b/docs/sessions/2026-03-10-003-proposals-triage-112.md
@@ -1,0 +1,32 @@
+# Session 2026-03-10-003 — Proposals Triage (Issue #112)
+
+**Date:** 2026-03-10
+**Branch:** docs/proposals-triage-112
+**Issue:** refs #112
+
+## Summary
+
+Triaged 5 stale "Proposed" Data Engineering proposals. All had concrete decisions already
+documented internally — the `Proposed` status header was stale.
+
+## Changes
+
+- `docs/proposals/etl-overwrite-pattern.md` — `Proposed` → `Accepted — Phase 2 data engineering; ADR-006 candidate pending`
+- `docs/proposals/testing-strategy.md` — `Proposed` → `Accepted — Phase 2 data engineering`
+- `docs/proposals/code-design-transform-separation.md` — `Proposed` → `Accepted — Phase 2 data engineering`
+- `docs/proposals/sdlc-catalog-lookup.md` — `Proposed` → `Accepted — Phase 2 data engineering`
+- `docs/proposals/wheel-packaging.md` — `Proposed` → `Accepted — Phase 2 data engineering; ADR-007 candidate pending`
+- `docs/proposals/README.md` — index updated to reflect all Accepted statuses
+
+## Disposition rationale
+
+All 5 proposals are Phase 2 data engineering work. Decisions were already made inside each
+file (Decision section with concrete parameters). No proposals were rejected — all represent
+deliberate design choices awaiting Phase 2 implementation.
+
+ADR-006 and ADR-007 candidates remain "not yet written" — this is expected for Phase 2.
+
+## No status.md changes needed
+
+No issues were opened or closed this session. Issue #112 severity unchanged (LOW).
+PR #70 (stale docs-restructure) remains open — human action required per status.md.


### PR DESCRIPTION
## Summary

- All 5 Data Engineering proposals had concrete decisions already documented internally — the `Proposed` status header was stale
- Updated `Status` in each proposal file from `Proposed` → `Accepted — Phase 2 data engineering`
- `etl-overwrite-pattern.md` and `wheel-packaging.md` also note ADR-006/ADR-007 candidates pending
- `docs/proposals/README.md` index updated to match

## No rejections

All 5 proposals represent deliberate Phase 2 design choices. No proposals were rejected.

## Pending human action

PR #70 (docs-restructure proposal, already implemented in PR #71) still needs to be closed by human — cannot be done via CI/CD per CLAUDE.md.

refs #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)