### PR TITLE
feat: GH Actions workflow — build wheel and deploy ETL bundle

### DIFF
--- a/.github/workflows/workload-etl.yaml
+++ b/.github/workflows/workload-etl.yaml
@@ -1,0 +1,103 @@
+name: workload-etl
+on:
+  push:
+    branches: [ "main" ]
+    paths: [ "etl/**" ]
+  workflow_dispatch:
+    inputs:
+      env:
+        description: "Target environment (dev / prod)"
+        required: true
+        default: dev
+        type: choice
+        options:
+          - dev
+          - prod
+
+concurrency:
+  group: etl-${{ github.event_name == 'push' && 'dev' || inputs.env }}
+  cancel-in-progress: true
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  TFSTATE_RG_NAME: rg-tfstate
+  TFSTATE_SA_NAME: st${{ secrets.TFSTATE_SA_UNIQ }}tfstate
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Azure login (OIDC)
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+
+      - name: Init workload-azure backend to read outputs
+        run: |
+          terraform -chdir=infra/workload-azure init \
+            -backend-config="resource_group_name=$TFSTATE_RG_NAME" \
+            -backend-config="storage_account_name=$TFSTATE_SA_NAME" \
+            -backend-config="container_name=workload-tfstate" \
+            -backend-config="key=azure.tfstate"
+
+      - name: Capture workload-azure outputs
+        id: azout
+        run: |
+          echo "WORKSPACE_URL=$(terraform -chdir=infra/workload-azure output -raw workspace_url)" >> $GITHUB_OUTPUT
+
+      - name: Set DATABRICKS_HOST
+        run: echo "DATABRICKS_HOST=https://${{ steps.azout.outputs.WORKSPACE_URL }}" >> $GITHUB_ENV
+
+      - name: Acquire Databricks token via Azure CLI
+        run: |
+          TOKEN=$(az account get-access-token \
+            --resource 2ff814a6-3304-4ab8-85cb-cd0e6f879c1d \
+            --query accessToken -o tsv)
+          echo "DATABRICKS_TOKEN=$TOKEN" >> $GITHUB_ENV
+
+      - name: Install Databricks CLI
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/databricks/setup-cli/main/install.sh | sh
+
+      - name: Set bundle target
+        id: target
+        run: |
+          if [ "${{ github.event_name }}" = "push" ]; then
+            echo "TARGET=dev" >> $GITHUB_OUTPUT
+          else
+            echo "TARGET=${{ inputs.env }}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Build wheel
+        run: |
+          pip install build
+          python -m build etl/
+
+      - name: Bundle deploy
+        working-directory: etl
+        run: |
+          databricks bundle deploy --target ${{ steps.target.outputs.TARGET }} \
+            --var "env=${{ steps.target.outputs.TARGET }}"
+
+      - name: Bundle run — etl-pipeline
+        working-directory: etl
+        run: |
+          databricks bundle run etl-pipeline \
+            --target ${{ steps.target.outputs.TARGET }} \
+            --var "env=${{ steps.target.outputs.TARGET }}" \
+            --no-wait=false

--- a/docs/sessions/2026-03-10-007-etl-deploy-workflow-129.md
+++ b/docs/sessions/2026-03-10-007-etl-deploy-workflow-129.md
@@ -1,0 +1,28 @@
+# Session 2026-03-10-007 — GH Actions ETL deploy workflow (#129)
+
+**Branch:** feature/129-etl-deploy-workflow
+**Issue:** #129
+**Depends on:** #125 merged (via PR #128)
+
+## What was done
+
+- Created `.github/workflows/workload-etl.yaml`
+  - Triggers: `push` to `main` (paths: `etl/**`); `workflow_dispatch` with `env` choice input (dev / prod)
+  - `concurrency` group prevents overlapping deploys per target
+  - Auth: Azure OIDC → Terraform init → capture `workspace_url` output → set `DATABRICKS_HOST`
+  - Databricks token: acquired from Azure CLI (`az account get-access-token`) — same SP used by other workloads
+  - Wheel build: `actions/setup-python@v5` + `pip install build` + `python -m build etl/`
+  - Target: `dev` for push; `${{ inputs.env }}` for workflow_dispatch
+  - `bundle deploy` then `bundle run etl-pipeline --no-wait=false`
+
+## Design notes
+
+- Follows the exact pattern of `workload-catalog.yaml` (OIDC auth, Terraform output capture, CLI install)
+- `push` → `dev` target only; `prod` requires explicit `workflow_dispatch` with `env=prod` — consistent with "Prod execution: CI/CD only, no manual runs"
+- Wheel build runs in the runner before `bundle deploy` so `etl/dist/*.whl` exists when the bundle is uploaded
+- No new secrets required — reuses `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_SUBSCRIPTION_ID`, `TFSTATE_SA_UNIQ`
+
+## Files changed
+
+- `.github/workflows/workload-etl.yaml` (new)
+- `docs/sessions/2026-03-10-007-etl-deploy-workflow-129.md` (this file)


### PR DESCRIPTION
## Summary

- `.github/workflows/workload-etl.yaml` — new workflow that builds the `mock_platform` wheel and deploys the ETL Asset Bundle to Databricks

## Behaviour

| Trigger | Target |
|---------|--------|
| `push` to `main` (paths: `etl/**`) | `dev` |
| `workflow_dispatch` with `env=dev` | `dev` |
| `workflow_dispatch` with `env=prod` | `prod` |

## Steps

1. Azure login (OIDC) — same SP as all other workloads
2. Terraform init on `workload-azure` backend → capture `workspace_url`
3. Acquire Databricks token via `az account get-access-token`
4. Install Databricks CLI
5. Setup Python 3.11 + `pip install build` + `python -m build etl/` → produces `etl/dist/*.whl`
6. `databricks bundle deploy --target <TARGET> --var "env=<TARGET>"`
7. `databricks bundle run etl-pipeline --target <TARGET> --no-wait=false`

## Design notes

- Follows `workload-catalog.yaml` pattern exactly (OIDC, Terraform outputs, CLI install)
- No new secrets required — reuses `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_SUBSCRIPTION_ID`, `TFSTATE_SA_UNIQ`
- `prod` target requires explicit `workflow_dispatch` — consistent with "Prod execution: CI/CD only, no manual runs"
- Wheel is built in the runner before `bundle deploy` so `etl/dist/*.whl` exists when the bundle is uploaded

## Test plan

- [ ] Merge and verify the workflow appears in the Actions tab
- [ ] Trigger `workflow_dispatch` with `env=dev`; confirm wheel builds and bundle deploys to dev target
- [ ] Confirm `etl-pipeline` job runs on Databricks and completes successfully
- [ ] Trigger `workflow_dispatch` with `env=prod`; confirm prod target is used

relates to #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)