### PR TITLE
fix: resolve notebook paths relative to bundle root in etl/resources/

### DIFF
--- a/etl/resources/etl-e2e-test.yml
+++ b/etl/resources/etl-e2e-test.yml
@@ -5,7 +5,7 @@ resources:
       tasks:
         - task_key: generate_and_test
           notebook_task:
-            notebook_path: ./notebooks/e2e_test.py
+            notebook_path: ../notebooks/e2e_test.py
             source: WORKSPACE
             base_parameters:
               env: "${var.env}"

--- a/etl/resources/etl-pipeline.yml
+++ b/etl/resources/etl-pipeline.yml
@@ -5,7 +5,7 @@ resources:
       tasks:
         - task_key: run_pipeline
           notebook_task:
-            notebook_path: ./notebooks/pipeline.py
+            notebook_path: ../notebooks/pipeline.py
             source: WORKSPACE
             base_parameters:
               env: "${var.env}"


### PR DESCRIPTION
## Summary

- `etl/resources/etl-pipeline.yml`: `./notebooks/pipeline.py` → `../notebooks/pipeline.py`
- `etl/resources/etl-e2e-test.yml`: `./notebooks/e2e_test.py` → `../notebooks/e2e_test.py`

Databricks CLI resolves relative paths in resource YAML files from the location of the resource file (`etl/resources/`), not the bundle root (`etl/`). The old `./notebooks/` paths pointed to the non-existent `etl/resources/notebooks/` directory, causing the `workload-etl` bundle deploy to fail with:

```
Error: notebook resources/notebooks/e2e_test.py not found
```

Changing to `../notebooks/` makes the paths resolve to `etl/notebooks/` as intended.

## Test plan

- [ ] `workload-etl` workflow runs bundle deploy without the "notebook not found" error
- [ ] ETL pipeline job and E2E test job are created successfully in Databricks

refs #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)