### PR TITLE
fix: resolve notebook paths relative to bundle root in etl/resources/

### DIFF
--- a/etl/resources/etl-e2e-test.yml
+++ b/etl/resources/etl-e2e-test.yml
@@ -5,7 +5,7 @@ resources:
       tasks:
         - task_key: generate_and_test
           notebook_task:
-            notebook_path: ./notebooks/e2e_test.py
+            notebook_path: ../notebooks/e2e_test.py
             source: WORKSPACE
             base_parameters:
               env: "${var.env}"

--- a/etl/resources/etl-pipeline.yml
+++ b/etl/resources/etl-pipeline.yml
@@ -5,7 +5,7 @@ resources:
       tasks:
         - task_key: run_pipeline
           notebook_task:
-            notebook_path: ./notebooks/pipeline.py
+            notebook_path: ../notebooks/pipeline.py
             source: WORKSPACE
             base_parameters:
               env: "${var.env}"


### PR DESCRIPTION
## Summary

- `etl/resources/etl-pipeline.yml`: `./notebooks/pipeline.py` → `../notebooks/pipeline.py`
- `etl/resources/etl-e2e-test.yml`: `./notebooks/e2e_test.py` → `../notebooks/e2e_test.py`

PR #132 merged this fix into `feature/129-etl-deploy-workflow`, but that branch was already merged into `main` first (PR #130). This PR applies the same fix directly to `main`.

The Databricks CLI resolves relative paths in resource YAML files from the resource file location (`etl/resources/`), not the bundle root (`etl/`). The old `./notebooks/` paths resolve to the non-existent `etl/resources/notebooks/`, causing `workload-etl` to fail:

```
Error: notebook resources/notebooks/pipeline.py not found
```

Changing to `../notebooks/` resolves correctly to `etl/notebooks/`.

## Test plan

- [ ] `workload-etl` workflow completes bundle deploy without "notebook not found" error
- [ ] ETL pipeline and E2E test jobs created in Databricks

refs #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)