### PR TITLE
fix: resolve whl library paths relative to bundle root in etl/resources/

### DIFF
--- a/etl/resources/etl-e2e-test.yml
+++ b/etl/resources/etl-e2e-test.yml
@@ -11,7 +11,7 @@ resources:
               env: "${var.env}"
               num_records: "50"
           libraries:
-            - whl: ./dist/*.whl
+            - whl: ../dist/*.whl
             - pypi:
                 package: faker
           new_cluster:

--- a/etl/resources/etl-pipeline.yml
+++ b/etl/resources/etl-pipeline.yml
@@ -10,7 +10,7 @@ resources:
             base_parameters:
               env: "${var.env}"
           libraries:
-            - whl: ./dist/*.whl
+            - whl: ../dist/*.whl
           new_cluster:
             spark_version: "14.3.x-scala2.12"
             node_type_id: "Standard_DS3_v2"


### PR DESCRIPTION
## Summary

- `etl/resources/etl-pipeline.yml`: `./dist/*.whl` → `../dist/*.whl`
- `etl/resources/etl-e2e-test.yml`: `./dist/*.whl` → `../dist/*.whl`

Same root cause as the notebook path fix (PR #133): the Databricks CLI resolves relative paths in resource YAML files from the resource file location (`etl/resources/`), not the bundle root (`etl/`). The `./dist/*.whl` pattern was resolving to the non-existent `etl/resources/dist/`, causing bundle deploy to fail after the notebook fix landed:

```
Error: no files match pattern: resources/dist/*.whl
  at resources.jobs.etl-e2e-test.tasks[0].libraries[0].whl
  in resources/etl-e2e-test.yml:14:15
```

Changing to `../dist/*.whl` resolves to `etl/dist/` where `python -m build etl/` outputs the wheel.

## Test plan

- [ ] `workload-etl` bundle deploy completes without "no files match pattern" error
- [ ] ETL pipeline and E2E test jobs created in Databricks workspace

refs #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)