### PR TITLE
fix: use tier-specific schemas (bronze/silver/gold) in ETL notebooks

### DIFF
--- a/etl/notebooks/e2e_test.py
+++ b/etl/notebooks/e2e_test.py
@@ -35,10 +35,9 @@ print(f"env = {env}, num_records = {num_records}")
 from mock_platform.catalog_lookup import get_catalog
 
 catalog = get_catalog(env)
-schema = "sales"
-bronze_table = f"`{catalog}`.`{schema}`.`orders_bronze`"
-silver_table = f"`{catalog}`.`{schema}`.`orders_silver`"
-gold_table = f"`{catalog}`.`{schema}`.`daily_sales_by_region`"
+bronze_table = f"`{catalog}`.`bronze`.`orders_bronze`"
+silver_table = f"`{catalog}`.`silver`.`orders_silver`"
+gold_table = f"`{catalog}`.`gold`.`daily_sales_by_region`"
 print(f"Target tables: {bronze_table}, {silver_table}, {gold_table}")
 
 # COMMAND ----------

--- a/etl/notebooks/pipeline.py
+++ b/etl/notebooks/pipeline.py
@@ -31,8 +31,7 @@ print(f"env = {env}")
 from mock_platform.catalog_lookup import get_catalog
 
 catalog = get_catalog(env)
-schema = "sales"
-print(f"catalog = {catalog}, schema = {schema}")
+print(f"catalog = {catalog}")
 
 # COMMAND ----------
 
@@ -43,8 +42,8 @@ print(f"catalog = {catalog}, schema = {schema}")
 
 from mock_platform.transform import clean_orders
 
-bronze_table = f"`{catalog}`.`{schema}`.`orders_bronze`"
-silver_table = f"`{catalog}`.`{schema}`.`orders_silver`"
+bronze_table = f"`{catalog}`.`bronze`.`orders_bronze`"
+silver_table = f"`{catalog}`.`silver`.`orders_silver`"
 
 print(f"Reading bronze: {bronze_table}")
 df_bronze = spark.table(bronze_table)
@@ -73,7 +72,7 @@ print("Silver write complete.")
 
 from mock_platform.transform import aggregate_daily_sales
 
-gold_table = f"`{catalog}`.`{schema}`.`daily_sales_by_region`"
+gold_table = f"`{catalog}`.`gold`.`daily_sales_by_region`"
 
 print(f"Reading silver: {silver_table}")
 df_silver_read = spark.table(silver_table)


### PR DESCRIPTION
## Summary

- `etl/notebooks/pipeline.py`: replace `schema = "sales"` with per-tier schema references
- `etl/notebooks/e2e_test.py`: same fix

Both notebooks were using a hardcoded `schema = "sales"` for all table references. That schema does not exist. `platform/configs/catalog_schema.yaml` defines three schemas: `bronze`, `silver`, `gold`. The tables now reference their correct schemas:

| Table | Before | After |
|-------|--------|-------|
| `orders_bronze` | `mock.sales.orders_bronze` | `mock.bronze.orders_bronze` |
| `orders_silver` | `mock.sales.orders_silver` | `mock.silver.orders_silver` |
| `daily_sales_by_region` | `mock.sales.daily_sales_by_region` | `mock.gold.daily_sales_by_region` |

Failure from last run:
```
[TABLE_OR_VIEW_NOT_FOUND] The table or view `mock`.`sales`.`orders_bronze` cannot be found.
```

## Test plan

- [ ] `workload-etl` bundle run — etl-pipeline completes without TABLE_OR_VIEW_NOT_FOUND
- [ ] `workload-etl` bundle run — etl-e2e-test writes and validates all three tier tables

refs #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)