### PR TITLE
fix: run etl-e2e-test instead of etl-pipeline in CI

### DIFF
--- a/.github/workflows/workload-etl.yaml
+++ b/.github/workflows/workload-etl.yaml
@@ -94,10 +94,10 @@ jobs:
           databricks bundle deploy --target ${{ steps.target.outputs.TARGET }} \
             --var "env=${{ steps.target.outputs.TARGET }}"
 
-      - name: Bundle run — etl-pipeline
+      - name: Bundle run — etl-e2e-test
         working-directory: etl
         run: |
-          databricks bundle run etl-pipeline \
+          databricks bundle run etl-e2e-test \
             --target ${{ steps.target.outputs.TARGET }} \
             --var "env=${{ steps.target.outputs.TARGET }}" \
             --no-wait=false


### PR DESCRIPTION
## Summary

- `.github/workflows/workload-etl.yaml`: replace `bundle run etl-pipeline` with `bundle run etl-e2e-test`

`etl-pipeline` is a **production** job — it reads from `mock.bronze.orders_bronze` which must be pre-populated by an upstream ingestion process. Running it in CI fails because no bronze data exists:

```
[TABLE_OR_VIEW_NOT_FOUND] The table or view `mock`.`bronze`.`orders_bronze` cannot be found.
```

`etl-e2e-test` is the correct CI job — it is fully self-contained:
1. Generates 50 synthetic orders with Faker
2. Writes them to `mock.bronze.orders_bronze`
3. Runs `clean_orders` → writes `mock.silver.orders_silver`
4. Runs `aggregate_daily_sales` → writes `mock.gold.daily_sales_by_region`
5. Asserts silver and gold schemas and row counts

## Test plan

- [ ] `workload-etl` CI run completes successfully end-to-end
- [ ] All schema and row-count assertions in `etl-e2e-test` pass

refs #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)