### PR TITLE
docs: mark MVP ETL pipeline as done in README Current Status

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,10 +231,10 @@ the full write-up.
 - SDLC variable parametrization across environments
 - GitHub Actions Workflow Dispatch for `dev`/`staging`
 - ADR documentation (5 ADRs)
+- MVP ETL pipeline using `saveAsTable` (bronze → silver → gold confirmed 2026-03-10)
 
 ### In Progress
 
-- MVP ETL pipeline using `saveAsTable`
 - README finalization for public release
 
 ### Known Issues


### PR DESCRIPTION
## Summary

Moves "MVP ETL pipeline using `saveAsTable`" from **In Progress** to **Done** in the `Current Status (MVP)` section of README.md, with confirmation date added.

Bronze → silver → gold tables confirmed in Databricks workspace GUI on 2026-03-10 (GH Actions run 22888609919, TERMINATED SUCCESS).

refs #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)