### PR TITLE
feat(etl): gold layer — use view instead of table for daily_sales_by_region

### DIFF
--- a/docs/sessions/2026-03-10-009-gold-view-141.md
+++ b/docs/sessions/2026-03-10-009-gold-view-141.md
@@ -1,0 +1,35 @@
+# Session 009 — Gold layer: view instead of table (issue #141)
+
+**Date:** 2026-03-10
+**Branch:** feature/gold-view-141
+**Issue:** refs #141
+
+## Goal
+
+Replace the gold-layer `saveAsTable` write with a `CREATE OR REPLACE VIEW` definition,
+aligning the implementation with ADR-004 (view layer access pattern).
+
+## Changes
+
+### `etl/notebooks/pipeline.py`
+- Removed `aggregate_daily_sales` import and DataFrame write for gold.
+- Added `spark.sql("CREATE OR REPLACE VIEW ...")` that defines `daily_sales_by_region`
+  as a SQL view over `orders_silver` (the silver table).
+- Updated docstring and Done section to reflect view vs. table.
+
+### `etl/notebooks/e2e_test.py`
+- Renamed `gold_table` → `gold_view` throughout for clarity.
+- Replaced gold `saveAsTable` step with the same `CREATE OR REPLACE VIEW` DDL.
+- Removed unused `aggregate_daily_sales` import.
+- All schema and row-count assertions unchanged — `spark.table()` works on views.
+
+### Not changed
+- `etl/src/mock_platform/transform.py` — `aggregate_daily_sales` retained; still used
+  by unit tests in `tests/unit/test_transform.py`.
+
+## Design rationale
+
+ADR-004 mandates a view layer for data consumer access. Materialising the gold aggregation
+as a Delta table was an unnecessary compute step — the aggregation is lightweight and
+always-fresh semantics are preferable for this dataset. The view reads directly from silver
+on every query, eliminating the redundant write and aligning with the stated architecture.

--- a/etl/notebooks/e2e_test.py
+++ b/etl/notebooks/e2e_test.py
@@ -37,8 +37,8 @@ from mock_platform.catalog_lookup import get_catalog
 catalog = get_catalog(env)
 bronze_table = f"`{catalog}`.`bronze`.`orders_bronze`"
 silver_table = f"`{catalog}`.`silver`.`orders_silver`"
-gold_table = f"`{catalog}`.`gold`.`daily_sales_by_region`"
-print(f"Target tables: {bronze_table}, {silver_table}, {gold_table}")
+gold_view = f"`{catalog}`.`gold`.`daily_sales_by_region`"
+print(f"Target tables: {bronze_table}, {silver_table}, {gold_view}")
 
 # COMMAND ----------
 
@@ -99,11 +99,11 @@ print("Bronze write complete.")
 # COMMAND ----------
 
 # MAGIC %md
-# MAGIC ## Step 2 — Run pipeline (bronze → silver → gold)
+# MAGIC ## Step 2 — Run pipeline (bronze → silver → gold view)
 
 # COMMAND ----------
 
-from mock_platform.transform import clean_orders, aggregate_daily_sales
+from mock_platform.transform import clean_orders
 
 df_bronze = spark.table(bronze_table)
 df_silver = clean_orders(df_bronze)
@@ -118,16 +118,21 @@ print("Silver write complete.")
 
 # COMMAND ----------
 
-df_silver_read = spark.table(silver_table)
-df_gold = aggregate_daily_sales(df_silver_read)
+gold_view_ddl = f"""
+CREATE OR REPLACE VIEW {gold_view} AS
+SELECT
+    region,
+    order_date,
+    CAST(SUM(quantity * unit_price) AS DECIMAL(18, 2)) AS total_revenue,
+    COUNT(order_id) AS order_count
+FROM {silver_table}
+GROUP BY region, order_date
+ORDER BY region, order_date
+"""
 
-(
-    df_gold.write
-    .mode("overwrite")
-    .option("overwriteSchema", "true")
-    .saveAsTable(gold_table)
-)
-print("Gold write complete.")
+print(f"Creating gold view: {gold_view}")
+spark.sql(gold_view_ddl)
+print("Gold view created.")
 
 # COMMAND ----------
 
@@ -164,7 +169,7 @@ print("Silver schema assertions passed.")
 # COMMAND ----------
 
 # --- Gold schema assertions ---
-df_gold_out = spark.table(gold_table)
+df_gold_out = spark.table(gold_view)
 gold_fields = {f.name: f for f in df_gold_out.schema.fields}
 
 expected_gold_columns = {"region", "order_date", "total_revenue", "order_count"}
@@ -192,7 +197,7 @@ silver_count = df_silver_out.count()
 gold_count = df_gold_out.count()
 
 assert silver_count > 0, "Silver table is empty after pipeline run."
-assert gold_count > 0, "Gold table is empty after pipeline run."
+assert gold_count > 0, "Gold view is empty after pipeline run."
 
 # Gold must have at most as many rows as silver (aggregation reduces rows)
 assert gold_count <= silver_count, (
@@ -221,4 +226,4 @@ print(f"Row-count checks passed. Silver: {silver_count} rows, Gold: {gold_count}
 print("All E2E assertions passed.")
 print(f"  bronze: {df_generated.count()} rows written")
 print(f"  silver: {silver_count} rows (after clean_orders)")
-print(f"  gold:   {gold_count} rows (after aggregate_daily_sales)")
+print(f"  gold:   {gold_count} rows (view over silver)")

--- a/etl/notebooks/pipeline.py
+++ b/etl/notebooks/pipeline.py
@@ -3,7 +3,8 @@
 # MAGIC # ETL Pipeline: Bronze → Silver → Gold
 # MAGIC
 # MAGIC Orchestration notebook. Reads bronze, applies transforms from the `mock_platform` wheel,
-# MAGIC and writes silver and gold tables via `saveAsTable(mode="overwrite")`.
+# MAGIC and writes silver via `saveAsTable(mode="overwrite")`. The gold layer is a SQL view
+# MAGIC (`CREATE OR REPLACE VIEW`) over silver — no separate write step (aligns with ADR-004).
 # MAGIC
 # MAGIC **Usage:** Deployed as the `etl-pipeline` job in `etl/databricks.yml`.
 
@@ -66,31 +67,27 @@ print("Silver write complete.")
 # COMMAND ----------
 
 # MAGIC %md
-# MAGIC ## Silver → Gold
+# MAGIC ## Silver → Gold (view)
 
 # COMMAND ----------
 
-from mock_platform.transform import aggregate_daily_sales
+gold_view = f"`{catalog}`.`gold`.`daily_sales_by_region`"
 
-gold_table = f"`{catalog}`.`gold`.`daily_sales_by_region`"
+view_ddl = f"""
+CREATE OR REPLACE VIEW {gold_view} AS
+SELECT
+    region,
+    order_date,
+    CAST(SUM(quantity * unit_price) AS DECIMAL(18, 2)) AS total_revenue,
+    COUNT(order_id) AS order_count
+FROM {silver_table}
+GROUP BY region, order_date
+ORDER BY region, order_date
+"""
 
-print(f"Reading silver: {silver_table}")
-df_silver_read = spark.table(silver_table)
-
-df_gold = aggregate_daily_sales(df_silver_read)
-df_gold.printSchema()
-print(f"Gold row count: {df_gold.count()}")
-
-# COMMAND ----------
-
-print(f"Writing gold: {gold_table}")
-(
-    df_gold.write
-    .mode("overwrite")
-    .option("overwriteSchema", "true")
-    .saveAsTable(gold_table)
-)
-print("Gold write complete.")
+print(f"Creating gold view: {gold_view}")
+spark.sql(view_ddl)
+print("Gold view created.")
 
 # COMMAND ----------
 
@@ -99,6 +96,6 @@ print("Gold write complete.")
 
 # COMMAND ----------
 
-print(f"Pipeline complete. Tables written:")
-print(f"  silver: {silver_table}")
-print(f"  gold:   {gold_table}")
+print(f"Pipeline complete.")
+print(f"  silver: {silver_table} (table)")
+print(f"  gold:   {gold_view} (view)")


### PR DESCRIPTION
## Summary

- Replaces `saveAsTable` in the gold step with `CREATE OR REPLACE VIEW` for `daily_sales_by_region`
- Gold view reads directly from `orders_silver` on every query — no materialisation step
- `aggregate_daily_sales` in `transform.py` is retained (still used by unit tests)

## Motivation

ADR-004 mandates a view layer for data consumer access. The gold aggregation is lightweight; always-fresh view semantics are preferable to an unnecessary Delta table write on every pipeline run.

## Files changed

| File | Change |
|------|--------|
| `etl/notebooks/pipeline.py` | Gold write → `spark.sql(CREATE OR REPLACE VIEW ...)` |
| `etl/notebooks/e2e_test.py` | Same DDL; `gold_table` → `gold_view`; removed unused import |
| `docs/sessions/2026-03-10-009-gold-view-141.md` | Session note |

## Test plan

- [ ] CI: `test-unit.yaml` passes (no change to `transform.py` logic)
- [ ] CI: `workload-etl.yaml` deploys updated notebooks
- [ ] Human: trigger `etl-e2e-test` job and verify gold view exists and assertions pass
- [ ] Human: trigger `etl-pipeline` job and verify gold view is recreated cleanly

refs #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)