### PR TITLE
fix(etl): drop existing gold table before CREATE OR REPLACE VIEW

### DIFF
--- a/docs/sessions/2026-03-11-001-drop-table-before-view.md
+++ b/docs/sessions/2026-03-11-001-drop-table-before-view.md
@@ -1,0 +1,21 @@
+# Session 2026-03-11-001 — Drop table before gold view
+
+## Goal
+Fix CI failure: `CREATE OR REPLACE VIEW` fails when `daily_sales_by_region` already exists as a Delta TABLE.
+
+## Root Cause
+PR #152 converted the gold layer from `saveAsTable` to `CREATE OR REPLACE VIEW`. The previous successful CI run (22888609919) had written the gold object as a Delta table. When the new view DDL ran against the existing table, Spark raised `EXPECT_VIEW_NOT_TABLE.NO_ALTERNATIVE` (SQLSTATE 42809).
+
+## Fix
+Added `DROP TABLE IF EXISTS {gold_view}` immediately before `CREATE OR REPLACE VIEW` in both notebooks:
+- `etl/notebooks/pipeline.py`
+- `etl/notebooks/e2e_test.py`
+
+This is a one-time migration guard. Once the table is gone and the view exists, subsequent runs are idempotent via `CREATE OR REPLACE VIEW`.
+
+## Artifacts
+- `etl/notebooks/pipeline.py` — drop step added
+- `etl/notebooks/e2e_test.py` — drop step added
+
+## Outcome
+PR created. Awaiting human review and CI confirmation.

--- a/etl/notebooks/e2e_test.py
+++ b/etl/notebooks/e2e_test.py
@@ -130,6 +130,8 @@ GROUP BY region, order_date
 ORDER BY region, order_date
 """
 
+print(f"Dropping existing table if present: {gold_view}")
+spark.sql(f"DROP TABLE IF EXISTS {gold_view}")
 print(f"Creating gold view: {gold_view}")
 spark.sql(gold_view_ddl)
 print("Gold view created.")

--- a/etl/notebooks/pipeline.py
+++ b/etl/notebooks/pipeline.py
@@ -85,6 +85,8 @@ GROUP BY region, order_date
 ORDER BY region, order_date
 """
 
+print(f"Dropping existing table if present: {gold_view}")
+spark.sql(f"DROP TABLE IF EXISTS {gold_view}")
 print(f"Creating gold view: {gold_view}")
 spark.sql(view_ddl)
 print("Gold view created.")


### PR DESCRIPTION
## Summary
- PR #152 converted the gold layer from `saveAsTable` to `CREATE OR REPLACE VIEW`, but the previous successful CI run had already written `daily_sales_by_region` as a Delta table
- `CREATE OR REPLACE VIEW` raises `EXPECT_VIEW_NOT_TABLE.NO_ALTERNATIVE` (SQLSTATE 42809) when the named object exists as a table
- Fix: add `DROP TABLE IF EXISTS {gold_view}` immediately before the view DDL in both `pipeline.py` and `e2e_test.py`

## Test plan
- [ ] CI `workload-etl` (push trigger) runs `bundle deploy` + `bundle run etl-e2e-test`
- [ ] `DROP TABLE IF EXISTS` silently no-ops on future runs once the view exists
- [ ] `CREATE OR REPLACE VIEW` succeeds — no `EXPECT_VIEW_NOT_TABLE` error
- [ ] All E2E assertions pass (schema, row count, region, revenue checks)

refs #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)