### PR TITLE
docs(adr): add ADR-006 (overwrite-only) and ADR-007 (wheel packaging)

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,34 @@ See [ADR-005](docs/adr/005-group-permissions.md) for full rationale.
 
 -----
 
+### ADR-006: Overwrite-Only Writes — Merge Pattern Deferred
+
+The ETL pipeline uses `saveAsTable(mode("overwrite"))` for the silver layer and
+`CREATE OR REPLACE VIEW` for the gold layer. `DeltaTable.merge()` (or SQL `MERGE INTO`) is
+explicitly deferred: a correct merge implementation requires upstream primary-key enforcement,
+a conflict-resolution strategy for late-arriving records, and an ingestion timestamp — none of
+which exist in the current pipeline. The conditions under which merge becomes necessary (fact
+tables, incremental loads, SCD Type 2) and the two candidate implementation paths (PySpark or
+SQL/Jinja2) are documented in the ADR.
+
+See [ADR-006](docs/adr/006-overwrite-only.md) for full rationale.
+
+-----
+
+### ADR-007: Wheel Packaging over `%run` for Shared ETL Code
+
+Shared ETL code (`transform.py`, `catalog_lookup.py`) is distributed to Databricks clusters
+as a Python wheel built via `pyproject.toml` and deployed via Asset Bundles `libraries`.
+`%run` and naive relative imports are rejected: `%run` path resolution breaks silently across
+environments, and Python relative imports do not work in Databricks notebooks (which are not
+executed as packages). The wheel build step runs in CI on every PR, catching packaging failures
+before they reach `bundle deploy`. Unit tests use an editable install on the GitHub Actions runner
+— no cluster required.
+
+See [ADR-007](docs/adr/007-wheel-packaging.md) for full rationale.
+
+-----
+
 ## Production Considerations
 
 These topics are not implemented in this mock environment due to cost and complexity constraints.
@@ -230,7 +258,7 @@ the full write-up.
 - Asset Bundles with environment-specific targets (`dev`, `staging`, `prod`)
 - SDLC variable parametrization across environments
 - GitHub Actions Workflow Dispatch for `dev`/`staging`
-- ADR documentation (5 ADRs)
+- ADR documentation (7 ADRs)
 - MVP ETL pipeline using `saveAsTable` (bronze → silver → gold confirmed 2026-03-10)
 
 ### In Progress

--- a/docs/adr/006-overwrite-only.md
+++ b/docs/adr/006-overwrite-only.md
@@ -1,0 +1,132 @@
+# ADR-006: Overwrite-Only Writes — Merge Pattern Deferred
+
+**Status:** Accepted
+**Date:** 2026-03-12
+
+---
+
+## Context
+
+The ETL pipeline processes Sales Orders through three medallion layers:
+
+- **Bronze** — raw ingestion, CSV-sourced or Faker-generated records, no transformation
+- **Silver** — cleaned and typed (type casting, null handling, dedup on `order_id`)
+- **Gold** — aggregated for consumption (`daily_sales_by_region`)
+
+All writes must be idempotent by construction (ADR-003). Two write patterns were candidates for
+the silver layer: full overwrite and upsert via merge.
+
+The gold layer is a SQL view rather than a table, which removes it from the overwrite-vs-merge
+decision entirely — `CREATE OR REPLACE VIEW` is inherently idempotent and has no merge analogue.
+
+---
+
+## Decision
+
+- **Silver layer:** `saveAsTable(mode("overwrite"))` with `overwriteSchema=true`
+- **Gold layer:** `CREATE OR REPLACE VIEW` — no separate write step (aligns with ADR-004)
+- **`DeltaTable.merge()` (or SQL `MERGE INTO`):** explicitly deferred — not implemented
+
+---
+
+## Rationale
+
+**Overwrite satisfies ADR-003 idempotency automatically.**
+A failed run can be retried immediately without inspecting or cleaning up partial state. No
+deduplication logic, no primary-key enforcement, and no conflict-resolution strategy is required
+at the write step.
+
+**A full batch reload is acceptable at current scale.**
+The Sales Orders dataset is small, bounded, and fully regenerated on every E2E test run. There is
+no SLA constraint that makes a full rewrite prohibitive. The cost difference between overwrite and
+incremental merge is negligible at this volume.
+
+**Merge requires upstream design decisions that are not yet made.**
+A correct merge implementation requires a stable primary key enforced upstream, a
+conflict-resolution strategy for late-arriving records, and an ingestion timestamp or equivalent
+ordering field. None of these exist in the current pipeline. Introducing merge without them would
+produce an implementation that looks incremental but silently produces incorrect results under
+retry or late-arrival conditions.
+
+**Overwrite makes the test contract simpler.**
+Unit tests operate on pure transformation functions (in `transform.py`) with no I/O. E2E tests
+generate a fresh dataset on every run. Overwrite semantics mean test assertions are always against
+a clean table state — no test setup or teardown required to handle residual data from a previous run.
+
+---
+
+## When Merge Becomes Necessary
+
+The overwrite pattern should be revisited when any of the following conditions arise:
+
+| Condition | Why overwrite breaks down |
+|-----------|--------------------------|
+| **Fact tables with late-arriving records** | Corrections that arrive after the initial load overwrite the corrected row with stale data on the next full reload |
+| **Incremental loads from high-volume sources** | Full rewrite latency becomes unacceptable as data volume grows (streaming sources, high-frequency APIs) |
+| **SCD Type 2 (preserve history)** | Overwrite destroys previous versions of a row; historical access requires a merge-based upsert with effective-date tracking |
+| **Multiple upstream sources contributing to the same table** | Full overwrite from one source silently deletes rows written by another |
+
+---
+
+## Design Changes Required When Merge Is Introduced
+
+The write step in `pipeline.py` must be replaced with an upsert operation keyed on `order_id`.
+Two implementation paths are candidates at that point:
+
+- **PySpark (`DeltaTable.merge()`)** — merge logic expressed in Python, consistent with the
+  existing `transform.py` / `pipeline.py` split. Transformation and persistence remain in the
+  same language layer.
+- **SQL (`MERGE INTO`) via Jinja2 template** — merge logic expressed in SQL, consistent with the
+  Jinja2 templating pattern already used in the Platform Layer for catalog/schema DDL. Suitable
+  if the merge logic grows complex enough that SQL readability outweighs the additional template
+  management overhead.
+
+Regardless of implementation path, the following must be defined before merge is introduced:
+
+- **`order_id` uniqueness enforcement upstream** — duplicate `order_id` values in bronze must be
+  resolved before the merge step, or the merge condition must be defined to handle them explicitly
+- **Conflict-resolution strategy** — a deterministic rule for which record wins when the same
+  `order_id` arrives multiple times (e.g., keep the record with the latest ingestion timestamp)
+- **Late-arrival handling** — a field (ingestion timestamp or `order_date`) that establishes
+  ordering for out-of-sequence records
+
+The implementation choice and the upstream enforcement design are deferred to the ADR that
+replaces or extends this one.
+
+---
+
+## Trade-offs Accepted
+
+- **Compute cost:** Full table rewrite on every run is more expensive than an incremental merge
+  for large tables. This trade-off is accepted: correctness and simplicity over cost optimization
+  at current scale (consistent with ADR-003).
+- **`overwriteSchema=true` silently drops schema:** If a column is removed from the transformation
+  output, the table schema changes without warning to downstream consumers. Acceptable for the mock
+  environment; in production, schema evolution must be controlled explicitly (see
+  `docs/proposals/etl-future-enhancements.md` §6).
+
+---
+
+## Rejected Alternatives
+
+**`mode("append")`** — produces duplicates on every retry. Violates ADR-003. Rejected.
+
+**`MERGE INTO` now** — over-engineering: implementing merge before the upstream primary key
+enforcement and late-arrival handling design is in place produces a merge that appears correct
+under the happy path but silently fails under late-arrival or retry conditions. The operational
+risk of a "merge-shaped bug" in production is higher than the operational risk of a known
+overwrite limitation that is explicitly documented.
+
+---
+
+## Consequences
+
+- Every pipeline run rewrites the full silver table. Downstream consumers reading during a pipeline
+  run will observe a momentary empty table (Delta Lake time-travel mitigates this in production if
+  `readChangeFeed` or snapshot isolation is used).
+- The `order_id` deduplication in `clean_orders()` (`transform.py`) uses `dropDuplicates`, which
+  makes no ordering guarantee when duplicates have different field values. This is acceptable for
+  overwrite; it must be replaced with a deterministic Window function if merge is introduced
+  (see `docs/proposals/etl-future-enhancements.md` §7).
+- When merge is introduced, this ADR should be superseded (marked **Superseded**) and replaced
+  with a new ADR documenting the merge design.

--- a/docs/adr/007-wheel-packaging.md
+++ b/docs/adr/007-wheel-packaging.md
@@ -1,0 +1,130 @@
+# ADR-007: Wheel Packaging over `%run` for Shared ETL Code
+
+**Status:** Accepted
+**Date:** 2026-03-12
+
+---
+
+## Context
+
+The ETL codebase is split across two concerns:
+
+- **Shared library code** (`transform.py`, `catalog_lookup.py`) — pure functions with no I/O,
+  independently testable, used by multiple notebooks
+- **Orchestration notebooks** (`pipeline.py`, `e2e_test.py`) — entry points that import shared
+  code and perform I/O (`spark.table`, `saveAsTable`, `CREATE OR REPLACE VIEW`)
+
+This split was established by the code-design-transform-separation proposal: business logic lives
+in the library, orchestration and persistence live in notebooks.
+
+To make the shared code available to notebooks running on a Databricks cluster, a distribution
+mechanism is required. Two approaches were evaluated: `%run` (and naive relative imports) and
+wheel packaging via `pyproject.toml`.
+
+---
+
+## Decision
+
+- Package `src/mock_platform/` as a Python wheel via `pyproject.toml` and `python -m build`
+- Distribute the wheel to clusters via Asset Bundles `libraries` in job resource YAMLs
+- `%run` and naive relative imports are rejected
+
+---
+
+## Why `%run` Fails on Clusters
+
+`%run` is a Databricks magic command that executes another notebook or `.py` file. It appears to
+solve the code-sharing problem but fails in practice for two reasons:
+
+**Path resolution is fragile across environments.**
+`%run path/to/file.py` resolves paths relative to the notebook's location in the Databricks
+Workspace (or DBFS). When notebooks are deployed to different Workspace paths in `dev` vs `prod`,
+the relative path breaks silently — the file may not be found, or a stale cached version may be
+executed. There is no compile-time error; the failure only surfaces at runtime on the cluster.
+
+**Naive relative imports do not work in Databricks notebooks.**
+Python's module import system (`from ..transform import clean_orders`) requires the calling file
+to be part of a Python package — i.e., the parent directory must contain an `__init__.py` and
+the package must be on `sys.path`. Databricks notebooks are not executed as part of a package;
+they are run as top-level scripts. Relative imports raise `ImportError` at runtime, and adding
+the source directory to `sys.path` manually is fragile, non-reproducible, and environment-specific.
+
+Both approaches require manual path management that differs between a developer's local machine,
+a CI runner, and a Databricks cluster — a different failure mode in each environment.
+
+---
+
+## Wheel Packaging Integration
+
+The wheel distribution pipeline maps directly onto the existing project structure:
+
+| Step | Tool | Output |
+|------|------|--------|
+| Define package | `pyproject.toml` (`setuptools`, `src/` layout) | Package metadata |
+| Build wheel | `python -m build --wheel --outdir dist/` | `dist/mock_platform-*.whl` |
+| Upload to Workspace | `databricks bundle deploy` (`libraries` stanza) | Wheel on cluster classpath |
+| Import in notebook | Standard Python: `from mock_platform.transform import clean_orders` | |
+
+The `libraries` stanza in job resource YAMLs (`etl/resources/etl-pipeline.yml`,
+`etl/resources/etl-e2e-test.yml`) references `../dist/*.whl`. On `bundle deploy`, the Databricks
+CLI resolves the glob, uploads the wheel to the Workspace, and injects it into the cluster
+configuration for the job. No manual DBFS copy or path manipulation is required.
+
+**CI integration:** `test-unit.yaml` runs `pip install build && python -m build --wheel --outdir dist/`
+after the test step on every PR. This verifies that the package builds successfully before a
+`bundle deploy` could be attempted — packaging failures are caught in CI, not at deploy time.
+
+**Local development:** Tests run via `pip install -e ".[dev]"` (editable install from the source
+tree). No wheel build is required for local testing — changes to `src/mock_platform/` take
+effect immediately. The wheel is only needed for cluster deployment.
+
+---
+
+## Trade-offs Accepted
+
+- **Additional build step in CI:** `pip install build && python -m build` adds a small step to
+  the CI workflow. This is standard Python toolchain; the overhead is negligible (~5–10s) and
+  justified by catching packaging issues before they reach `bundle deploy`.
+- **Wheel must be rebuilt before every `bundle deploy`:** Changes to `src/mock_platform/` require
+  a new `bundle deploy` (not just `bundle run`) to propagate the updated wheel to the cluster.
+  This is intentional: the wheel version deployed is always the one built from the current commit.
+- **`dist/` is not committed:** The built wheel is a build artifact, not source. `dist/` is
+  gitignored; CI and deploy always build fresh from source.
+
+---
+
+## Rejected Alternatives
+
+**`%run`** — path fragility and environment coupling documented above. Also untestable outside
+Databricks: a test suite that validates `%run`-based imports cannot run on a GitHub Actions runner
+without a Databricks cluster. Rejected.
+
+**DBFS direct copy (`dbutils.fs.cp`)** — requires a manually managed upload step outside of
+CI/CD, is not reproducible, and creates an undeclared dependency on a DBFS path that may differ
+between environments. Rejected.
+
+**Inline functions duplicated across notebooks** — violates the code-design-transform-separation
+principle. Transform logic becomes untestable in isolation and must be kept in sync across
+multiple notebooks manually. Rejected.
+
+**`setup.py` instead of `pyproject.toml`** — `setup.py` is the legacy build interface; `pyproject.toml`
+with `setuptools` is the current standard (PEP 517/518). Both are technically equivalent for this
+use case; `pyproject.toml` is used to align with current Python toolchain conventions.
+
+---
+
+## Consequences
+
+- Every change to `src/mock_platform/` requires a `bundle deploy` (not just `bundle run`) to take
+  effect on the cluster. Developers who run `bundle run` without a preceding `bundle deploy` after
+  a code change will run against the previously deployed wheel version.
+- The `dist/*.whl` glob in the job YAML means the package version in `pyproject.toml` does not
+  need to be incremented on every deploy — the glob picks the latest built artifact. Version
+  management becomes relevant only if multiple wheel versions need to coexist (e.g., pinned
+  prod vs rolling dev).
+- Unit tests on the GitHub Actions runner use `pip install -e ".[dev]"` — no wheel is involved.
+  This means CI can validate transform logic without a Databricks cluster or a wheel build step,
+  keeping the test feedback loop fast.
+- Adding a new module to `src/mock_platform/` follows the same pattern: add the file, update
+  tests, and the next `bundle deploy` will include it automatically via the `src/` layout
+  discovery in `pyproject.toml`.

--- a/docs/sessions/2026-03-12-003-adr-006-007.md
+++ b/docs/sessions/2026-03-12-003-adr-006-007.md
@@ -1,0 +1,34 @@
+# Session 2026-03-12-003 — adr-006-007
+
+**Branch:** docs/2026-03-12-003-adr-006-007
+**Issue:** #126
+**PR:** (fill in when created)
+**Outcome:** completed
+
+## Objective
+
+Write ADR-006 (overwrite-only pattern, merge deferred) and ADR-007 (wheel packaging over `%run`),
+and add both entries to the ADR section of README.md.
+
+This is PR 3 of 3 in the data engineering implementation plan.
+
+## What was done
+
+- Created `docs/adr/006-overwrite-only.md`
+- Created `docs/adr/007-wheel-packaging.md`
+- Updated `README.md` ADR section with summaries for ADR-006 and ADR-007
+- Updated `README.md` "Done" item: ADR count 5 → 7
+
+## Decisions
+
+- ADR-006 documents the overwrite-only decision without prescribing PySpark or SQL/Jinja2 for
+  the future merge implementation — both are listed as candidates and the choice is deferred.
+- ADR-007 documents the wheel packaging rationale including the CI integration and the
+  `%run` failure modes on clusters.
+
+## Artifacts
+
+- `docs/adr/006-overwrite-only.md` — created
+- `docs/adr/007-wheel-packaging.md` — created
+- `README.md` — updated (ADR section + Done count)
+- `docs/sessions/2026-03-12-003-adr-006-007.md` — this file


### PR DESCRIPTION
## Summary

- **ADR-006** (`docs/adr/006-overwrite-only.md`): documents the overwrite-only write pattern for the silver layer and `CREATE OR REPLACE VIEW` for gold. Covers when merge becomes necessary (fact tables, incremental loads, SCD Type 2), and describes two candidate implementation paths when merge is introduced: PySpark `DeltaTable.merge()` or SQL `MERGE INTO` via Jinja2 template. The choice between them is deferred.
- **ADR-007** (`docs/adr/007-wheel-packaging.md`): documents wheel packaging over `%run`. Covers the two failure modes of `%run` (path fragility across environments, relative import incompatibility in Databricks notebooks), the CI integration (`python -m build` after tests on every PR), and trade-offs of the wheel approach.
- **README.md**: added ADR-006 and ADR-007 summaries in the ADR section; updated ADR count from 5 to 7.

This is PR 3 of 3 in the data engineering implementation plan (`docs/proposals/data-engineering-implementation-plan.md` §6).

## Test plan

- [ ] ADR-006 accurately reflects the implemented write pattern (`pipeline.py` — `saveAsTable` overwrite for silver, `CREATE OR REPLACE VIEW` for gold)
- [ ] ADR-006 documents both PySpark and SQL/Jinja2 as merge candidates without prescribing one
- [ ] ADR-007 accurately reflects the CI workflow (`test-unit.yaml` — wheel build step after pytest)
- [ ] ADR-007 accurately reflects the Asset Bundles integration (`etl/resources/*.yml` — `libraries: - whl: ../dist/*.whl`)
- [ ] README summaries are 2–3 sentences and link to the full ADRs

refs #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)