### PR TITLE
fix(ci): add reset_metastore_state flag to exercise metastore import branch 3

### DIFF
--- a/.github/workflows/workload-dbx.yaml
+++ b/.github/workflows/workload-dbx.yaml
@@ -10,6 +10,10 @@ on:
       destroy:
         type: boolean
         default: false
+      reset_metastore_state:
+        description: "Remove metastore from tfstate before import step (test branch 3 of import logic)"
+        type: boolean
+        default: false
   workflow_call:
     inputs:
       destroy:
@@ -94,6 +98,14 @@ jobs:
         run: |
           tflint --init --chdir=infra/workload-dbx
           tflint --chdir=infra/workload-dbx
+
+      # Test helper: drop the metastore from state to simulate a partial-destroy scenario.
+      # Only runs when reset_metastore_state=true is passed via workflow_dispatch.
+      # Not exposed in workflow_call, so orchestrators cannot trigger this accidentally.
+      - name: "Test setup: remove metastore from state"
+        if: inputs.reset_metastore_state == true && inputs.destroy != true
+        run: |
+          terraform -chdir=infra/workload-dbx state rm databricks_metastore.this || true
 
       # Discover and import an existing metastore into Terraform state if needed.
       # Handles the "failed-destroy recovery" case: if a previous destroy run failed

--- a/docs/sessions/2026-03-17-001-metastore-import-test-flag.md
+++ b/docs/sessions/2026-03-17-001-metastore-import-test-flag.md
@@ -1,0 +1,34 @@
+# Session 2026-03-17-001 — metastore-import-test-flag
+
+**Branch:** fix/2026-03-17-001-metastore-import-test-flag
+**Issue:** #82
+**PR:** (fill in when created)
+**Outcome:** (fill in at session end)
+
+## Objective
+
+Exercise Branch 3 of the dynamic metastore import step in `workload-dbx.yaml` —
+"Found existing metastore — importing into Terraform state" — which has never been
+triggered in CI.
+
+## What was done
+
+Added a `reset_metastore_state` boolean input (default `false`) to `workload-dbx.yaml`.
+When `true` (only triggerable via `workflow_dispatch`), a new step runs
+`terraform state rm databricks_metastore.this` before the import step, simulating the
+"partial destroy" scenario described in issue #82.
+
+Orchestrators (`orchestrator-up`, `orchestrator-down`) are unaffected — they call
+`workload-dbx.yaml` without passing the new input, so it defaults to `false`.
+
+## Decisions
+
+- Implemented as a flag on the existing workflow rather than a separate test workflow,
+  to avoid file bloat and keep all metastore logic co-located.
+- Flag is `workflow_dispatch`-only (not exposed via `workflow_call`), so orchestrators
+  cannot accidentally trigger it.
+- Guarded by `inputs.destroy != true` to prevent accidental state removal on destroy runs.
+
+## Artifacts
+
+- `.github/workflows/workload-dbx.yaml` — added `reset_metastore_state` input and step


### PR DESCRIPTION
## Summary

- Adds a `reset_metastore_state` boolean input (default `false`) to `workload-dbx.yaml` under `workflow_dispatch` only
- New step removes `databricks_metastore.this` from Terraform state before the dynamic import step, simulating the partial-destroy scenario in issue #82
- Orchestrators (`orchestrator-up`, `orchestrator-down`) are unaffected — input is not exposed via `workflow_call`, so it defaults to `false`

## Test plan

- [ ] Merge PR
- [ ] Trigger `workload-dbx` via `workflow_dispatch` with `reset_metastore_state=true`, `destroy=false`
- [ ] Confirm step "Test setup: remove metastore from state" runs and succeeds
- [ ] Confirm import step logs "Found existing metastore `<uuid>` — importing into Terraform state" (Branch 3)
- [ ] Confirm `terraform apply` completes successfully
- [ ] Record run ID in session note as evidence; close issue #82 manually

refs #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)